### PR TITLE
Update pmm-info.sh

### DIFF
--- a/pmm-info.sh
+++ b/pmm-info.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Created by Roel Van de Paar, Percona LLC
 
-echo 'QA PMM Info Script v0.08'
+echo 'QA PMM Info Script v0.09'
 echo '==================== uname -a'
 uname -a 2>&1 | sed 's|^|  |'
 echo '==================== /proc/version'
@@ -33,8 +33,8 @@ echo '==================== PMM list (sudo pmm-admin list):'
 sudo pmm-admin list 2>&1 | grep -v '^$' | sed 's|^|  |'
 
 if [ "$1" != "" ]; then
-  echo '==================== Extended info: cat /opt/.../VERSION inside docker container:'
-  sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') find /opt/ -name VERSION -exec echo {} \; -exec cat {} \; 2>&1 | grep -v '^$' | sed 's|^|  |'
+  echo '==================== Extended info: cat /*/*VERSION inside docker container:'
+  sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') find / -name \*VERSION -exec echo {} \; -exec cat {} \; 2>&1 | grep -v '^$' | sed 's|^|  |'
   echo '==================== Extended info: cat /var/log/nginx/error.log inside docker container:'
   sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') cat /var/log/nginx/error.log 2>&1 | grep -v '^$' | sed 's|^|  |'
   echo '==================== Extended info: cat /var/log/consul.log inside docker container:'


### PR DESCRIPTION
To reflect changes in versioning, new command searches from `/` for `*VERSION` files. Note that we are now using `/var/lib/grafana/PERCONA_DASHBOARDS_VERSION` to reflect current container version.

Previous command and output:

```
[root@pmm ~]#  sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') find /opt/ -name VERSION -exec echo {} \; -exec cat {} \; 2>&1 | grep -v '^$' | sed 's|^|  |'
  /opt/prometheus/data/VERSION
  1
```

New proposed command and output:

```
[root@pmm ~]#   sudo docker exec -it $(sudo docker ps -a | grep pmm | grep 'Up.*pmm-server' | sed 's|[ \t].*||') find / -name \*VERSION -exec echo {} \; -exec cat {} \; 2>&1 | grep -v '^$' | sed 's|^|  |'
  /opt/prometheus/data/VERSION
  1
  /usr/share/percona-dashboards/VERSION
  1.2.0
  /var/lib/grafana/PERCONA_DASHBOARDS_VERSION
  1.2.0
```