### PR TITLE
Fix get_download_link.sh

### DIFF
--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -286,7 +286,7 @@ get_link(){
     else
       if [[ ${SOURCE} = 0 ]]; then
         BASE_LINK="https://dev.mysql.com/get/Downloads/MySQL-${VERSION}/"
-        TARBALL=$(wget -qO- https://dev.mysql.com/downloads/mysql/${VERSION}.html\?os\=2|grep -o -P "(mysql|MySQL)-${VERSION_FULL}.*${BUILD_ARCH}.tar.gz"|grep -v "mysql-test"|head -n1)
+        TARBALL=$(wget -qO- https://dev.mysql.com/downloads/mysql/${VERSION}.html\?os\=2|grep -o -E "(mysql|MySQL)-${VERSION_FULL}.*${BUILD_ARCH}.tar.gz"|grep -v "mysql-test"|head -n1)
         LINK="${BASE_LINK}${TARBALL}"
       else
         LINK="https://dev.mysql.com/get/Downloads/MySQL-${VERSION}/mysql-${VERSION_FULL}.tar.gz"
@@ -363,10 +363,10 @@ get_link(){
 
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        TARBALL=$(wget -qO- https://www.mongodb.org/dl/linux/x86_64 | grep -o -P "mongodb-linux-x86_64${DISTRIBUTION}-${VERSION}\..{1,6}\.tgz" | grep -viE "(\-rc|\-beta|\-alpha)+" | head -n1)
+        TARBALL=$(wget -qO- https://www.mongodb.org/dl/linux/x86_64 | grep -o -E "mongodb-linux-x86_64${DISTRIBUTION}-${VERSION}\..{1,6}\.tgz" | grep -viE "(\-rc|\-beta|\-alpha)+" | head -n1)
         LINK="${BASE_LINK}${TARBALL}"
       else
-        TARBALL=$(wget -qO- https://www.mongodb.org/dl/src | grep -o -P "mongodb-src-r${VERSION}\..{1,6}\.tar.gz" | grep -viE "(\-rc|\-beta|\-alpha)+" | head -n1)
+        TARBALL=$(wget -qO- https://www.mongodb.org/dl/src | grep -o -E "mongodb-src-r${VERSION}\..{1,6}\.tar.gz" | grep -viE "(\-rc|\-beta|\-alpha)+" | head -n1)
         LINK="${BASE_LINK}${TARBALL}"
       fi
     else
@@ -384,7 +384,7 @@ get_link(){
     fi
 
     if [[ -z ${VERSION_FULL} ]]; then
-      VERSION_FULL=$(wget -qO- https://releases.hashicorp.com/vault/ |grep -o "vault_.*"|grep -vP "alpha|beta|rc|ent"|sed "s:</a>::"|sed "s:vault_::"|head -n1)
+      VERSION_FULL=$(wget -qO- https://releases.hashicorp.com/vault/ |grep -o "vault_.*"|grep -vE "alpha|beta|rc|ent"|sed "s:</a>::"|sed "s:vault_::"|head -n1)
       TARBALL="vault_${VERSION_FULL}_linux_${BUILD_ARCH}.zip"
       LINK="${BASE_LINK}${VERSION_FULL}/${TARBALL}"
     else
@@ -400,7 +400,7 @@ get_link(){
     fi
 
     if [[ -z ${VERSION_FULL} ]]; then
-      TARBALL=$(wget -qO- https://www.enterprisedb.com/download-postgresql-binaries|grep -oP "postgresql-${VERSION}.*${BUILD_ARCH}-.*.tar.gz")
+      TARBALL=$(wget -qO- https://www.enterprisedb.com/download-postgresql-binaries|grep -oE "postgresql-${VERSION}.*${BUILD_ARCH}-.*.tar.gz")
       LINK="${BASE_LINK}${TARBALL}"
     else
       LINK="${BASE_LINK}postgresql-${VERSION_FULL}-1-linux${BUILD_ARCH}-binaries.tar.gz"

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -100,7 +100,7 @@ if [[ -z "${VERSION}" && "${PRODUCT}" = "mariadb" ]]; then VERSION="10.4"; fi
 if [[ -z "${VERSION}" && "${PRODUCT}" = "psmdb" ]]; then VERSION="4.2"; fi
 if [[ -z "${VERSION}" && "${PRODUCT}" = "mongodb" ]]; then VERSION="4.2"; fi
 if [[ -z "${VERSION}" && "${PRODUCT}" = "postgresql" ]]; then
-  VERSION=$(wget -qO- https://www.enterprisedb.com/download-postgresql-binaries|grep -oP "postgresql-.*-x64-.*.tar.gz"|head -n1|grep -oP "[0-9]+\.[0-9]+(\.[0-9]+)?")
+  VERSION=$(wget -qO- https://www.enterprisedb.com/download-postgresql-binaries|grep -oE "postgresql-.*-x64-.*.tar.gz"|head -n1|grep -oE "[0-9]+\.[0-9]+(\.[0-9]+)?"|head -n1)
 fi
 
 if [[ "${DISTRIBUTION}" = *"-"* ]]; then
@@ -400,7 +400,7 @@ get_link(){
     fi
 
     if [[ -z ${VERSION_FULL} ]]; then
-      TARBALL=$(wget -qO- https://www.enterprisedb.com/download-postgresql-binaries|grep -oE "postgresql-${VERSION}.*${BUILD_ARCH}-.*.tar.gz")
+      TARBALL=$(wget -qO- https://www.enterprisedb.com/download-postgresql-binaries|grep -oE "postgresql-${VERSION}.*?${BUILD_ARCH}-.*?.tar.gz"|head -n 1)
       LINK="${BASE_LINK}${TARBALL}"
     else
       LINK="${BASE_LINK}postgresql-${VERSION_FULL}-1-linux${BUILD_ARCH}-binaries.tar.gz"

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -160,10 +160,11 @@ get_link(){
     if [[ "${VERSION}" = "5.5" || "${VERSION}" = "5.6" ]]; then
       OPT="\.[0-9]+"
     fi
-    if [[ "${VERSION}" != "5.5" ]]; then OPT2=".${SSL_VER}"; fi
+    if [[ "${VERSION}" == "5.6" ]]; then OPT2=".${SSL_VER}"; fi
+    if [[ "${VERSION}" == "5.7" ]]; then OPT2=".glibc2.12"; fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-rel[0-9]+${OPT}-[0-9]+\.[0-9]+\.[0-9]+\.Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-rel[0-9]+${OPT}-[0-9]+\.[0-9]+(\.[0-9]+)?\.Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/tarball/${LINK}"; fi
       else
         LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-[0-9]+\.[0-9]+\.tar\.gz"|head -n1)

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -192,7 +192,7 @@ get_link(){
     else OPT=""; fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/binary/|grep -oE "percona-server-mongodb-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?${OPT}-${BUILD_ARCH}(\.glibc2.17)?\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/binary/|grep -oE "percona-server-mongodb-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?${OPT}-${BUILD_ARCH}(\.glibc\d\.\d+)?\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/binary/tarball/${LINK}"; fi
       else
         LINK=$(wget -qO- https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/source/|grep -oE "percona-server-mongodb-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -276,11 +276,11 @@ get_link(){
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
         BASE_LINK="https://dev.mysql.com/get/Downloads/MySQL-${VERSION}/"
-        TARBALL=$(wget -qO- https://dev.mysql.com/downloads/mysql/${VERSION}.html\?os\=2|grep -o -P "(mysql|MySQL)-[0-9]+\.[0-9]+\.[0-9]+.*${BUILD_ARCH}\.tar\..."|grep -v "mysql-test"|head -n1)
+        TARBALL=$(wget -qO- https://dev.mysql.com/downloads/mysql/${VERSION}.html\?os\=2|grep -o -E "(mysql|MySQL)-${VERSION}\.[0-9]+.*${BUILD_ARCH}\.tar\..."|grep -v "mysql-test"|head -n1)
         LINK="${BASE_LINK}${TARBALL}"
       else
         BASE_LINK="https://dev.mysql.com/get/Downloads/MySQL-${VERSION}/"
-        TARBALL=$(wget -qO- https://dev.mysql.com/downloads/mysql/${VERSION}.html\?os\=src|grep -o -P "(mysql|MySQL)-[0-9]+\.[0-9]+\.[0-9]+\.tar\..."|head -n1)
+        TARBALL=$(wget -qO- https://dev.mysql.com/downloads/mysql/${VERSION}.html\?os\=src|grep -o -E "(mysql|MySQL)-${VERSION}\.[0-9]+\.tar\..."|head -n1)
         LINK="${BASE_LINK}${TARBALL}"
       fi
     else

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -185,12 +185,14 @@ get_link(){
     fi
 
   elif [[ "${PRODUCT}" = "psmdb" && "${BUILD_ARCH}" = "x86_64" ]]; then
-    if [[ "${DISTRIBUTION}" = "ubuntu" ]]; then OPT="xenial";
-    elif [[ "${DISTRIBUTION}" = "centos" ]]; then OPT="centos6";
-    else OPT="${DISTRIBUTION}"; fi
+    if [[ "${VERSION}" = "3.4" ]]; then
+      if [[ "${DISTRIBUTION}" = "ubuntu" ]]; then OPT="-xenial";
+      elif [[ "${DISTRIBUTION}" = "centos" ]]; then OPT="-centos6";
+      else OPT="-${DISTRIBUTION}"; fi
+    else OPT=""; fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/binary/|grep -oE "percona-server-mongodb-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?-${OPT}-${BUILD_ARCH}\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/binary/|grep -oE "percona-server-mongodb-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?${OPT}-${BUILD_ARCH}(\.glibc2.17)?\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/binary/tarball/${LINK}"; fi
       else
         LINK=$(wget -qO- https://www.percona.com/downloads/percona-server-mongodb-${VERSION}/LATEST/source/|grep -oE "percona-server-mongodb-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -227,7 +227,7 @@ get_link(){
         TARBALL="percona-xtrabackup-${VERSION_FULL}-Linux-${BUILD_ARCH}.${OPT}.tar.gz"
         if [[ ! -z ${TARBALL} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraBackup-${VERSION}/Percona-XtraBackup-${VERSION_FULL}/binary/tarball/${TARBALL}"; fi
       else
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraBackup-${VERSION}/LATEST/source/|grep -oE "percona-xtrabackup-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraBackup-${VERSION}/LATEST/source/|grep -oE "percona-xtrabackup-[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraBackup-${VERSION}/LATEST/source/tarball/${LINK}"; fi
       fi
     else

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -142,7 +142,7 @@ get_link(){
         #LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-${OPT}[0-9]+-Linux\.${BUILD_ARCH}\.${SSL_VER}\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/tarball/Percona-Server-${PS_VER_MAJ}-${OPT}${PS_VER_MIN}-Linux.${BUILD_ARCH}.${SSL_VER}.tar.gz"; fi
       else
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/|grep -oE "percona-server-${VERSION}\.[0-9]+-${OPT}[0-9]+\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/|grep -oE "percona-server-${VERSION}\.[0-9]+-${OPT}[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/tarball/${LINK}"; fi
       fi
     else

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -168,7 +168,7 @@ get_link(){
         LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster[-_]${VERSION}\.[0-9]+(-rel[0-9]+)?${OPT}-[0-9]+\.[0-9]+(\.[0-9]+)?[\._]Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/tarball/${LINK}"; fi
       else
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-[0-9]+\.[0-9]+\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/tarball/${LINK}"; fi
       fi
     else

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -162,9 +162,10 @@ get_link(){
     fi
     if [[ "${VERSION}" == "5.6" ]]; then OPT2=".${SSL_VER}"; fi
     if [[ "${VERSION}" == "5.7" ]]; then OPT2=".glibc2.12"; fi
+    if [[ "${VERSION}" == "8.0" ]]; then OPT2=".glibc2.17"; fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-rel[0-9]+${OPT}-[0-9]+\.[0-9]+(\.[0-9]+)?\.Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
+        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster[-_]${VERSION}\.[0-9]+(-rel[0-9]+)?${OPT}-[0-9]+\.[0-9]+(\.[0-9]+)?[\._]Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
         if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/tarball/${LINK}"; fi
       else
         LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-[0-9]+\.[0-9]+\.tar\.gz"|head -n1)

--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -10,6 +10,16 @@
   ./get_download_link.sh --product ps --version 8.0
 }
 
+@test "check ps 5.6 source" {
+  ./get_download_link.sh --product ps --version 5.6 --source
+}
+@test "check ps 5.7 source" {
+  ./get_download_link.sh --product ps --version 5.7 --source
+}
+@test "check ps 8.0 source" {
+  ./get_download_link.sh --product ps --version 8.0 --source
+}
+
 @test "check pxc 5.5" {
   ./get_download_link.sh --product pxc --version 5.5
 }
@@ -22,6 +32,20 @@
 @test "check pxc 8.0" {
   ./get_download_link.sh --product pxc --version 8.0
 }
+
+@test "check pxc 5.5 source" {
+  ./get_download_link.sh --product pxc --version 5.5 --source
+}
+@test "check pxc 5.6 source" {
+  ./get_download_link.sh --product pxc --version 5.6 --source
+}
+@test "check pxc 5.7 source" {
+  ./get_download_link.sh --product pxc --version 5.7 --source
+}
+@test "check pxc 8.0 source" {
+  ./get_download_link.sh --product pxc --version 8.0 --source
+}
+
 
 @test "check psmdb 3.4" {
   ./get_download_link.sh --product psmdb --version 3.4
@@ -36,8 +60,25 @@
   ./get_download_link.sh --product psmdb --version 4.2
 }
 
+@test "check psmdb 3.4 source" {
+  ./get_download_link.sh --product psmdb --version 3.4 --source
+}
+@test "check psmdb 3.6 source" {
+  ./get_download_link.sh --product psmdb --version 3.6 --source
+}
+@test "check psmdb 4.0 source" {
+  ./get_download_link.sh --product psmdb --version 4.0 --source
+}
+@test "check psmdb 4.2 source" {
+  ./get_download_link.sh --product psmdb --version 4.2 --source
+}
+
 @test "check pt" {
   ./get_download_link.sh --product pt
+}
+
+@test "check pt source" {
+  ./get_download_link.sh --product pt --source
 }
 
 @test "check pxb 2.4" {
@@ -47,8 +88,19 @@
   ./get_download_link.sh --product pxb --version 8.0
 }
 
+@test "check pxb 2.4 source" {
+  ./get_download_link.sh --product pxb --version 2.4 --source
+}
+@test "check pxb 8.0 source" {
+  ./get_download_link.sh --product pxb --version 8.0 --source
+}
+
 @test "check pmm-client" {
   ./get_download_link.sh --product pmm-client
+}
+
+@test "check pmm-client source" {
+  ./get_download_link.sh --product pmm-client --source
 }
 
 @test "check mysql 5.5" {
@@ -64,6 +116,13 @@
   ./get_download_link.sh --product mysql --version 8.0
 }
 
+@test "check mysql 5.7 source" {
+  ./get_download_link.sh --product mysql --version 5.7 --source
+}
+@test "check mysql 8.0 source" {
+  ./get_download_link.sh --product mysql --version 8.0 --source
+}
+
 @test "check mariadb 10.2" {
   ./get_download_link.sh --product mariadb --version 10.2
 }
@@ -72,6 +131,16 @@
 }
 @test "check mariadb 10.4" {
   ./get_download_link.sh --product mariadb --version 10.4
+}
+
+@test "check mariadb 10.2 source" {
+  ./get_download_link.sh --product mariadb --version 10.2 --source
+}
+@test "check mariadb 10.3 source" {
+  ./get_download_link.sh --product mariadb --version 10.3 --source
+}
+@test "check mariadb 10.4 source" {
+  ./get_download_link.sh --product mariadb --version 10.4 --source
 }
 
 @test "check mongodb 3.4" {
@@ -89,6 +158,10 @@
 
 @test "check proxysql" {
   ./get_download_link.sh --product proxysql
+}
+
+@test "check proxysql source" {
+  ./get_download_link.sh --product proxysql --source
 }
 
 @test "check vault" {

--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -10,6 +10,22 @@
   ./get_download_link.sh --product ps --version 8.0
 }
 
+@test "check ps for centos" {
+  run ./get_download_link.sh --product ps --distribution centos
+  [ "$status" -eq 0 ]
+  [ "$(echo $output | grep -c 'ssl101')" -eq 1 ]
+}
+@test "check ps for ubuntu bionic" {
+  run ./get_download_link.sh --product ps --distribution ubuntu-bionic
+  [ "$status" -eq 0 ]
+  [ "$(echo $output | grep -c 'ssl102')" -eq 1 ]
+}
+@test "check ps for debian stretch" {
+  run ./get_download_link.sh --product ps --distribution debian-stretch
+  [ "$status" -eq 0 ]
+  [ "$(echo $output | grep -c 'ssl102')" -eq 1 ]
+}
+
 @test "check ps 5.6 source" {
   ./get_download_link.sh --product ps --version 5.6 --source
 }
@@ -73,6 +89,12 @@
   ./get_download_link.sh --product psmdb --version 4.2 --source
 }
 
+@test "check psmdb 3.4 for centos" {
+  run ./get_download_link.sh --product psmdb --version 3.4 --distribution centos
+  [ "$status" -eq 0 ]
+  [ "$(echo $output | grep -c 'centos6')" -eq 1 ]
+}
+
 @test "check pt" {
   ./get_download_link.sh --product pt
 }
@@ -93,6 +115,17 @@
 }
 @test "check pxb 8.0 source" {
   ./get_download_link.sh --product pxb --version 8.0 --source
+}
+
+@test "check pxb 2.4 for centos" {
+  run ./get_download_link.sh --product pxb --version 2.4 --distribution centos
+  [ "$status" -eq 0 ]
+  [ "$(echo $output | grep -c 'libgcrypt145')" -eq 1 ]
+}
+@test "check pxb 8.0 for centos" {
+  run ./get_download_link.sh --product pxb --version 8.0 --distribution centos
+  [ "$status" -eq 0 ]
+  [ "$(echo $output | grep -c 'glibc2.12')" -eq 1 ]
 }
 
 @test "check pmm-client" {

--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -136,12 +136,15 @@
   ./get_download_link.sh --product pmm-client --source
 }
 
-@test "check mysql 5.5" {
-  ./get_download_link.sh --product mysql --version 5.5
+@test "check mysql 5.5 fails" {
+  run ./get_download_link.sh --product mysql --version 5.5
+  [ "$status" -eq 1 ]
 }
-@test "check mysql 5.6" {
-  ./get_download_link.sh --product mysql --version 5.6
+@test "check mysql 5.6 fails" {
+  run ./get_download_link.sh --product mysql --version 5.6
+  [ "$status" -eq 1 ]
 }
+
 @test "check mysql 5.7" {
   ./get_download_link.sh --product mysql --version 5.7
 }

--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -1,109 +1,100 @@
 #!/usr/bin/env bats
 
-@test "check ps" {
-  run ./get_download_link.sh --product ps --version 5.6
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product ps --version 5.7
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product ps --version 8.0
-  [ "$status" -eq 0 ]
+@test "check ps 5.6" {
+  ./get_download_link.sh --product ps --version 5.6
+}
+@test "check ps 5.7" {
+  ./get_download_link.sh --product ps --version 5.7
+}
+@test "check ps 8.0" {
+  ./get_download_link.sh --product ps --version 8.0
 }
 
-@test "check pxc" {
-  run ./get_download_link.sh --product pxc --version 5.5
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product pxc --version 5.6
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product pxc --version 5.7
-  [ "$status" -eq 0 ]
+@test "check pxc 5.5" {
+  ./get_download_link.sh --product pxc --version 5.5
+}
+@test "check pxc 5.6" {
+  ./get_download_link.sh --product pxc --version 5.6
+}
+@test "check pxc 5.7" {
+  ./get_download_link.sh --product pxc --version 5.7
+}
+@test "check pxc 8.0" {
+  ./get_download_link.sh --product pxc --version 8.0
 }
 
-@test "check psmdb" {
-  run ./get_download_link.sh --product psmdb --version 3.4
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product psmdb --version 3.6
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product psmdb --version 4.0
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product psmdb --version 4.2
-  [ "$status" -eq 0 ]
+@test "check psmdb 3.4" {
+  ./get_download_link.sh --product psmdb --version 3.4
+}
+@test "check psmdb 3.6" {
+  ./get_download_link.sh --product psmdb --version 3.6
+}
+@test "check psmdb 4.0" {
+  ./get_download_link.sh --product psmdb --version 4.0
+}
+@test "check psmdb 4.2" {
+  ./get_download_link.sh --product psmdb --version 4.2
 }
 
 @test "check pt" {
-  run ./get_download_link.sh --product pt
-  [ "$status" -eq 0 ]
+  ./get_download_link.sh --product pt
 }
 
-@test "check pxb" {
-  run ./get_download_link.sh --product pxb --version 2.4
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product pxb --version 8.0
-  [ "$status" -eq 0 ]
+@test "check pxb 2.4" {
+  ./get_download_link.sh --product pxb --version 2.4
+}
+@test "check pxb 8.0" {
+  ./get_download_link.sh --product pxb --version 8.0
 }
 
 @test "check pmm-client" {
-  run ./get_download_link.sh --product pmm-client
-  [ "$status" -eq 0 ]
+  ./get_download_link.sh --product pmm-client
 }
 
-@test "check mysql" {
-  run ./get_download_link.sh --product mysql --version 5.5
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mysql --version 5.6
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mysql --version 5.7
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mysql --version 8.0
-  [ "$status" -eq 0 ]
+@test "check mysql 5.5" {
+  ./get_download_link.sh --product mysql --version 5.5
+}
+@test "check mysql 5.6" {
+  ./get_download_link.sh --product mysql --version 5.6
+}
+@test "check mysql 5.7" {
+  ./get_download_link.sh --product mysql --version 5.7
+}
+@test "check mysql 8.0" {
+  ./get_download_link.sh --product mysql --version 8.0
 }
 
-@test "check mariadb" {
-  run ./get_download_link.sh --product mariadb --version 10.2
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mariadb --version 10.3
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mariadb --version 10.4
-  [ "$status" -eq 0 ]
+@test "check mariadb 10.2" {
+  ./get_download_link.sh --product mariadb --version 10.2
+}
+@test "check mariadb 10.3" {
+  ./get_download_link.sh --product mariadb --version 10.3
+}
+@test "check mariadb 10.4" {
+  ./get_download_link.sh --product mariadb --version 10.4
 }
 
-@test "check mongodb" {
-  run ./get_download_link.sh --product mongodb --version 3.4
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mongodb --version 3.6
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mongodb --version 4.0
-  [ "$status" -eq 0 ]
-
-  run ./get_download_link.sh --product mongodb --version 4.2
-  [ "$status" -eq 0 ]
+@test "check mongodb 3.4" {
+  ./get_download_link.sh --product mongodb --version 3.4
+}
+@test "check mongodb 3.6" {
+  ./get_download_link.sh --product mongodb --version 3.6
+}
+@test "check mongodb 4.0" {
+  ./get_download_link.sh --product mongodb --version 4.0
+}
+@test "check mongodb 4.2" {
+  ./get_download_link.sh --product mongodb --version 4.2
 }
 
 @test "check proxysql" {
-  run ./get_download_link.sh --product proxysql
-  [ "$status" -eq 0 ]
+  ./get_download_link.sh --product proxysql
 }
 
 @test "check vault" {
-  run ./get_download_link.sh --product vault
-  [ "$status" -eq 0 ]
+  ./get_download_link.sh --product vault
 }
 
 @test "check postgresql" {
-  run ./get_download_link.sh --product postgresql
-  [ "$status" -eq 0 ]
+  ./get_download_link.sh --product postgresql
 }


### PR DESCRIPTION
This PR fixes most of the broken tests and failures to provide a link in the `get_download_link.sh` script, expands the test coverage to source tarballs and to non-default distribution variants, and addresses an issue where requesting a MySQL 5.5 or 5.6 link would return an 8.0 link instead, by making sure it fails instead of providing the wrong link. Less-often used paths of the script probably remain broken, but the main "happy paths" under test should at least be working.

A known issue left is that, while the test for PostgreSQL passes, and a link is provided when no version is specified, due to the website used as source of truth being somewhat outdated, the latest version it provides is 9.3. In any case, I'm not sure how feasible it would be to fix this to bring it up-to-date to the current version, since [Postgres itself stopped providing raw binary tarballs after 12.4](https://www.postgresql.org/ftp/binary/), switching to source distribution and packaged binaries only.