### PR TITLE
Fixing replication job

### DIFF
--- a/ps-tests/jenkins/ps57/test-ps-replication.groovy
+++ b/ps-tests/jenkins/ps57/test-ps-replication.groovy
@@ -94,8 +94,11 @@ pipeline {
                 fi
                 wget -q ${PT_BIN}
                 wget -q ${PXB_BIN}
-                PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
-                mv binary.tar.gz ${PS_TARBALL}
+                # Rename PS binary tarball in case its name is binary.tar.gz.
+                if echo "${PS_BIN}" | grep -Eq "binary.tar.gz"; then
+                  PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
+                  mv binary.tar.gz ${PS_TARBALL}
+                fi
                 cd -
                 git clone https://github.com/Percona-QA/percona-qa.git --depth 1
                 ${WORKSPACE}/percona-qa/ps-async-repl-test.sh --workdir=${WORKSPACE}/${TEST_DIR} --build-number=${BUILD_NUMBER} --testcase=${TEST_CASE} --storage-engine=innodb
@@ -146,8 +149,11 @@ pipeline {
                 fi
                 wget -q ${PT_BIN}
                 wget -q ${PXB_BIN}
-                PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
-                mv binary.tar.gz ${PS_TARBALL}
+                # Rename PS binary tarball in case its name is binary.tar.gz.
+                if echo "${PS_BIN}" | grep -Eq "binary.tar.gz"; then
+                  PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
+                  mv binary.tar.gz ${PS_TARBALL}
+                fi
                 cd -
                 git clone https://github.com/Percona-QA/percona-qa.git --depth 1
                 ${WORKSPACE}/percona-qa/ps-async-repl-test.sh --workdir=${WORKSPACE}/${TEST_DIR} --build-number=${BUILD_NUMBER} --testcase=${TEST_CASE} --storage-engine=rocksdb
@@ -198,8 +204,11 @@ pipeline {
                 fi
                 wget -q ${PT_BIN}
                 wget -q ${PXB_BIN}
-                PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
-                mv binary.tar.gz ${PS_TARBALL}
+                # Rename PS binary tarball in case its name is binary.tar.gz.
+                if echo "${PS_BIN}" | grep -Eq "binary.tar.gz"; then
+                  PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
+                  mv binary.tar.gz ${PS_TARBALL}
+                fi
                 cd -
                 git clone https://github.com/Percona-QA/percona-qa.git --depth 1
                 ${WORKSPACE}/percona-qa/ps-async-repl-test.sh --workdir=${WORKSPACE}/${TEST_DIR} --build-number=${BUILD_NUMBER} --testcase=${TEST_CASE} --storage-engine=tokudb
@@ -250,8 +259,11 @@ pipeline {
                 fi
                 wget -q ${PT_BIN}
                 wget -q ${PXB_BIN}
-                PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
-                mv binary.tar.gz ${PS_TARBALL}
+                # Rename PS binary tarball in case its name is binary.tar.gz.
+                if echo "${PS_BIN}" | grep -Eq "binary.tar.gz"; then
+                  PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
+                  mv binary.tar.gz ${PS_TARBALL}
+                fi
                 cd -
                 git clone https://github.com/Percona-QA/percona-qa.git --depth 1
                 ${WORKSPACE}/percona-qa/ps-async-repl-test.sh --workdir=${WORKSPACE}/${TEST_DIR} --build-number=${BUILD_NUMBER} --testcase=${TEST_CASE} --with-encryption --keyring-plugin=file
@@ -302,8 +314,11 @@ pipeline {
                 fi
                 wget -q ${PT_BIN}
                 wget -q ${PXB_BIN}
-                PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
-                mv binary.tar.gz ${PS_TARBALL}
+                # Rename PS binary tarball in case its name is binary.tar.gz.
+                if echo "${PS_BIN}" | grep -Eq "binary.tar.gz"; then
+                  PS_TARBALL="$(tar -ztf binary.tar.gz|head -n1|sed 's:/$::').tar.gz"
+                  mv binary.tar.gz ${PS_TARBALL}
+                fi
                 cd -
                 git clone https://github.com/Percona-QA/percona-qa.git --depth 1
                 ${WORKSPACE}/percona-qa/ps-async-repl-test.sh --workdir=${WORKSPACE}/${TEST_DIR} --build-number=${BUILD_NUMBER} --testcase=${TEST_CASE} --with-encryption --keyring-plugin=vault


### PR DESCRIPTION
When 'PS_BIN = build' is selected the percona-server-5.7-pipeline is run. It generated PS binary tarball with the binary.tar.gz name. The ps-async-repl-test.sh script checks presence of the binary tarball based on presence of file matching "?ercona-?erver*" pattern. binary.tar.gz renaming was commented so ps-async-repl-test.sh script "failed on the "Check PS binary tar ball"
FIX:
check whether download link contains binary.tar.gz pattern and rename downloaded binary tarball using '?ercona-?erver*' pattern. So if some other pattern is used, like the download link to web site (eg https://downloads.percona.com/downloads/TESTING/ps-5.7.37-40/Percona-Server-5.7.37-40-Linux.x86_64.glibc2.17.tar.gz) the name stays the same.