### PR TITLE
Updated PS and PXC part of get_download_link.sh file

### DIFF
--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -112,14 +112,12 @@ get_link(){
   local OPT=""
   local OPT2=""
 
-  if [[ "${DISTRIBUTION}" = "ubuntu" || "${DISTRIBUTION}" = "debian" ]]; then
-    if [[ "${DIST_REL}" = "bionic" || "${DIST_REL}" = "stretch" ]]; then
-      SSL_VER="ssl102"
-    else
-      SSL_VER="ssl100"
-    fi
+  if [[ "${DISTRIBUTION}" = "ubuntu" && "${DIST_REL}" = "jammy" ]]; then
+    GLIBC_VERSION="glibc2.35-zenfs."
+    SSL_VER=""
   else
-    SSL_VER="ssl101"
+    GLIBC_VERSION="glibc2.17."
+    SSL_VER=""
   fi
 
   if [[ $(grep -o "\." <<< "${VERSION}" | wc -l) -gt 1 ]]; then
@@ -130,28 +128,29 @@ get_link(){
   fi
 
   if [[ "${PRODUCT}" = "ps" ]]; then
-    if [[ "${VERSION}" = "5.5" || "${VERSION}" = "5.6" ]]; then
+    if [[ "${VERSION}" = "5.6" ]]; then
+      GLIBC_VERSION=""
+      SSL_VER="ssl101."
       OPT="rel"
       if [[ ${SOURCE} = 1 ]]; then OPT=${OPT#rel}; fi
     fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?"|head -n1)
+        LINK=$(wget -qO- https://downloads.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?"|head -n1)
         PS_VER_MAJ=$(echo "${LINK}" | cut -d- -f3)
         PS_VER_MIN=$(echo "${LINK}" | cut -d- -f4)
-        #LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/|grep -oE "Percona-Server-${VERSION}\.[0-9]+-${OPT}[0-9]+-Linux\.${BUILD_ARCH}\.${SSL_VER}\.tar\.gz"|head -n1)
-        if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/tarball/Percona-Server-${PS_VER_MAJ}-${OPT}${PS_VER_MIN}-Linux.${BUILD_ARCH}.${SSL_VER}.tar.gz"; fi
+        if [[ ! -z ${LINK} ]]; then LINK="https://downloads.percona.com/downloads/Percona-Server-${VERSION}/LATEST/binary/tarball/Percona-Server-${PS_VER_MAJ}-${OPT}${PS_VER_MIN}-Linux.${BUILD_ARCH}.${SSL_VER}${GLIBC_VERSION}tar.gz"; fi
       else
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/|grep -oE "percona-server-${VERSION}\.[0-9]+-${OPT}[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)
-        if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/tarball/${LINK}"; fi
+        LINK=$(wget -qO- https://downloads.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/|grep -oE "percona-server-${VERSION}\.[0-9]+-${OPT}[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)
+        if [[ ! -z ${LINK} ]]; then LINK="https://downloads.percona.com/downloads/Percona-Server-${VERSION}/LATEST/source/tarball/${LINK}"; fi
       fi
     else
       VERSION_UPSTREAM=$(echo "${VERSION_FULL}" | awk -F '-' '{print $1}')
       VERSION_PERCONA=$(echo "${VERSION_FULL}" | awk -F '-' '{print $2}')
       if [[ ${SOURCE} = 0 ]]; then
-        LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/Percona-Server-${VERSION_FULL}/binary/tarball/Percona-Server-${VERSION_UPSTREAM}-${VERSION_PERCONA}-Linux.${BUILD_ARCH}.${SSL_VER}.tar.gz"
+        LINK="https://downloads.percona.com/downloads/Percona-Server-${VERSION}/Percona-Server-${VERSION_FULL}/binary/tarball/Percona-Server-${VERSION_UPSTREAM}-${VERSION_PERCONA}-Linux.${BUILD_ARCH}.${SSL_VER}.tar.gz"
       else
-        LINK="https://www.percona.com/downloads/Percona-Server-${VERSION}/Percona-Server-${VERSION_FULL}/source/tarball/percona-server-${VERSION_UPSTREAM}-${VERSION_PERCONA}.tar.gz"
+        LINK="https://downloads.percona.com/downloads/Percona-Server-${VERSION}/Percona-Server-${VERSION_FULL}/source/tarball/percona-server-${VERSION_UPSTREAM}-${VERSION_PERCONA}.tar.gz"
       fi
     fi
 

--- a/get_download_link.sh
+++ b/get_download_link.sh
@@ -156,19 +156,15 @@ get_link(){
 
   elif [[ "${PRODUCT}" = "pxc" ]]; then
     DL_VERSION="${VERSION//./}"
-    if [[ "${VERSION}" = "5.5" || "${VERSION}" = "5.6" ]]; then
-      OPT="\.[0-9]+"
-    fi
-    if [[ "${VERSION}" == "5.6" ]]; then OPT2=".${SSL_VER}"; fi
     if [[ "${VERSION}" == "5.7" ]]; then OPT2=".glibc2.12"; fi
     if [[ "${VERSION}" == "8.0" ]]; then OPT2=".glibc2.17"; fi
     if [[ -z ${VERSION_FULL} ]]; then
       if [[ ${SOURCE} = 0 ]]; then
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster[-_]${VERSION}\.[0-9]+(-rel[0-9]+)?${OPT}-[0-9]+\.[0-9]+(\.[0-9]+)?[\._]Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
-        if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/tarball/${LINK}"; fi
+        LINK=$(wget -qO- https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/|grep -oE "Percona-XtraDB-Cluster[-_]${VERSION}\.[0-9]+(-rel[0-9]+)?${OPT}-[0-9]+\.[0-9]+(\.[0-9]+)?[\._]Linux\.${BUILD_ARCH}${OPT2}\.tar\.gz"|head -n1)
+        if [[ ! -z ${LINK} ]]; then LINK="https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/binary/tarball/${LINK}"; fi
       else
-        LINK=$(wget -qO- https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)
-        if [[ ! -z ${LINK} ]]; then LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/tarball/${LINK}"; fi
+        LINK=$(wget -qO- https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/|grep -oE "Percona-XtraDB-Cluster-${VERSION}\.[0-9]+-[0-9]+(\.[0-9]+)?\.tar\.gz"|head -n1)
+        if [[ ! -z ${LINK} ]]; then LINK="https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/LATEST/source/tarball/${LINK}"; fi
       fi
     else
       VERSION_UPSTREAM=$(echo "${VERSION_FULL}" | awk -F '-' '{print $1}')
@@ -177,9 +173,9 @@ get_link(){
       VERSION_WSREP_TMP=$(echo "${VERSION_WSREP}" | sed 's/\(.*\)\./\1-/')
       if [[ "${VERSION}" = "5.7" ]]; then VERSION_WSREP_TMP="${VERSION_WSREP_TMP%-*}"; fi
       if [[ ${SOURCE} = 0 ]]; then
-        LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-${VERSION_WSREP}/binary/tarball/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-rel${VERSION_PERCONA}-${VERSION_WSREP}.Linux.${BUILD_ARCH}${OPT2}.tar.gz"
+        LINK="https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-${VERSION_WSREP}/binary/tarball/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-rel${VERSION_PERCONA}-${VERSION_WSREP}.Linux.${BUILD_ARCH}${OPT2}.tar.gz"
       else
-        LINK="https://www.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-${VERSION_WSREP}/source/tarball/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-${VERSION_WSREP}.tar.gz"
+        LINK="https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-${DL_VERSION}/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-${VERSION_WSREP}/source/tarball/Percona-XtraDB-Cluster-${VERSION_UPSTREAM}-${VERSION_WSREP}.tar.gz"
       fi
     fi
 

--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -13,17 +13,17 @@
 @test "check ps for centos" {
   run ./get_download_link.sh --product ps --distribution centos
   [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'ssl101')" -eq 1 ]
+  [ "$(echo $output | grep -c 'glibc2.17')" -eq 1 ]
 }
 @test "check ps for ubuntu bionic" {
   run ./get_download_link.sh --product ps --distribution ubuntu-bionic
   [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'ssl102')" -eq 1 ]
+  [ "$(echo $output | grep -c 'glibc2.17')" -eq 1 ]
 }
-@test "check ps for debian stretch" {
-  run ./get_download_link.sh --product ps --distribution debian-stretch
+@test "check ps for ubuntu jammy" {
+  run ./get_download_link.sh --product ps --distribution ubuntu-jammy
   [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'ssl102')" -eq 1 ]
+  [ "$(echo $output | grep -c 'glibc2.35')" -eq 1 ]
 }
 
 @test "check ps 5.6 source" {

--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -36,12 +36,6 @@
   ./get_download_link.sh --product ps --version 8.0 --source
 }
 
-@test "check pxc 5.5" {
-  ./get_download_link.sh --product pxc --version 5.5
-}
-@test "check pxc 5.6" {
-  ./get_download_link.sh --product pxc --version 5.6
-}
 @test "check pxc 5.7" {
   ./get_download_link.sh --product pxc --version 5.7
 }
@@ -49,12 +43,6 @@
   ./get_download_link.sh --product pxc --version 8.0
 }
 
-@test "check pxc 5.5 source" {
-  ./get_download_link.sh --product pxc --version 5.5 --source
-}
-@test "check pxc 5.6 source" {
-  ./get_download_link.sh --product pxc --version 5.6 --source
-}
 @test "check pxc 5.7 source" {
   ./get_download_link.sh --product pxc --version 5.7 --source
 }


### PR DESCRIPTION
Old tarballs are getting downloaded , updated code to download latest source and binary tarballs 

Tried to download after updating code and it looks good :

```
-rw-r--r-- 1 puneet.kaushik percona  51M Feb  3  2021 percona-server-5.6.51-91.0.tar.gz
-rw-r--r-- 1 puneet.kaushik percona 133M Feb  8  2021 Percona-Server-5.6.51-rel91.0-Linux.x86_64.ssl101.tar.gz
-rw-r--r-- 1 puneet.kaushik percona 541M Nov 11 07:46 percona-server-8.0.30-22.tar.gz
-rw-r--r-- 1 puneet.kaushik percona 727M Nov 11 10:00 Percona-Server-8.0.30-22-Linux.x86_64.glibc2.17.tar.gz
-rw-r--r-- 1 puneet.kaushik percona 743M Nov 19 11:02 Percona-Server-8.0.30-22-Linux.x86_64.glibc2.35-zenfs.tar.gz
-rw-r--r-- 1 puneet.kaushik percona  88M Nov 22 15:48 percona-server-5.7.40-43.tar.gz
-rw-r--r-- 1 puneet.kaushik percona 555M Nov 22 16:32 Percona-Server-5.7.40-43-Linux.x86_64.glibc2.17.tar.gz
```
