### PR TITLE
Fix get_downloads_link after website update

### DIFF
--- a/get_download_link_test.bats
+++ b/get_download_link_test.bats
@@ -1,188 +1,402 @@
 #!/usr/bin/env bats
 
-# Check file existence at generated link with wget in spider mode. Check that file length is not 'unspecified'.
-function  check_file(){
+function execute_test(){
+  for arg
+  do
+    case "$arg" in
+      -p | --product )
+      local test_product="$2"
+      shift 2
+      ;;
+      -v | --version )
+      local version="$2"
+      local test_version="--version ${version}"
+      shift 2
+      ;;
+      -d | --distribution )
+      local distribution="$2"
+      local test_distribution="--distribution ${distribution}"
+      shift 2
+      ;;
+      -g | --glibc )
+      local glibc="$2"
+      shift 2
+      ;;
+      -s | --source )
+      local test_source="--source"
+      ;;
+    esac
+  done
+  # run get_download_link command
+  echo "Executed query: run ./get_download_link.sh --product ${test_product} ${test_version} ${test_source} ${test_distribution}"
+  run ./get_download_link.sh --product ${test_product} ${test_version} ${test_source} ${test_distribution}
+  # check whether command was executed successfully
+  [ "$status" -eq 0 ]
+  # check file existence at generated link with wget in spider mode. Check that file length is not 'unspecified'.
   echo -e "generaled_link = ${output}"
   wget_output="$(wget --spider ${output} 2>&1)"
-  echo -e "Check generated link correctness. The wget output 'Length' is 'unspecified'"
+  echo -e "Check generated link correctness. The wget output 'Length' may be 'unspecified'"
   [ "$(echo $wget_output | grep 'Length' | grep -c 'unspecified')" -eq 0 ]
+  # if the glibc and version was passed: check that version in the generated link is the same as the passed version.
+  if [[ -n ${glibc} ]]; then
+    echo -e "Check generated link glibc. The glibc in link is incorrect"
+    [ "$(echo ${output} | egrep -c "${glibc}")" -eq 1 ]
+  fi
+  if [[ -n ${version} ]]; then
+    echo -e "Check generated link version. The version in link is incorrect"
+    [ "$(echo ${output} | egrep -c "${version}")" -eq 1 ]
+  fi
 }
 
 @test "check ps 5.6" {
-  run ./get_download_link.sh --product ps --version 5.6
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product ps --version 5.6
+}
+@test "check ps 5.6.49" {
+  execute_test --product ps --version 5.6.49
+}
+@test "check ps 5.6.49-89" {
+  execute_test --product ps --version 5.6.49-89
+}
+@test "check ps 5.6.49-89.0" {
+  execute_test --product ps --version 5.6.49-89.0
 }
 @test "check ps 5.7" {
-  run ./get_download_link.sh --product ps --version 5.7
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product ps --version 5.7
+}
+@test "check ps 5.7.37" {
+  execute_test --product ps --version 5.7.37
+}
+@test "check ps 5.7.37-40" {
+  execute_test --product ps --version 5.7.37-40
 }
 @test "check ps 8.0" {
-  run ./get_download_link.sh --product ps --version 8.0
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product ps --version 8.0
+}
+@test "check ps 8.0.31" {
+  execute_test --product ps --version 8.0.31
+}
+@test "check ps 8.0.31-23" {
+  execute_test --product ps --version 8.0.31-23
 }
 @test "check ps for centos" {
-  run ./get_download_link.sh --product ps --distribution centos
-  [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'glibc2.17')" -eq 1 ]
-  check_file
+  execute_test --product ps --distribution centos --glibc glibc2.17
 }
 @test "check ps for ubuntu bionic" {
-  run ./get_download_link.sh --product ps --distribution ubuntu-bionic
-  [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'glibc2.17')" -eq 1 ]
-  check_file
+  execute_test --product ps --distribution ubuntu-bionic --glibc glibc2.17
 }
 @test "check ps for ubuntu jammy" {
-  run ./get_download_link.sh --product ps --distribution ubuntu-jammy
-  [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'glibc2.35')" -eq 1 ]
-  check_file
+  execute_test --product ps --distribution ubuntu-jammy --glibc glibc2.35
 }
 @test "check ps 5.6 source" {
-  run ./get_download_link.sh --product ps --version 5.6 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product ps --version 5.6 --source
+}
+@test "check ps 5.6.49 source" {
+  execute_test --product ps --version 5.6.49 --source
+}
+@test "check ps 5.6.49-89 source" {
+  execute_test --product ps --version 5.6.49-89 --source
+}
+@test "check ps 5.6.49-89.0 source" {
+  execute_test --product ps --version 5.6.49-89.0 --source
 }
 @test "check ps 5.7 source" {
-  run ./get_download_link.sh --product ps --version 5.7 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product ps --version 5.7 --source
+}
+@test "check ps 5.7.37 source" {
+  execute_test --product ps --version 5.7.37 --source
+}
+@test "check ps 5.7.37-40" source {
+  execute_test --product ps --version 5.7.37-40 --source
 }
 @test "check ps 8.0 source" {
-  run ./get_download_link.sh --product ps --version 8.0 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product ps --version 8.0 --source
 }
+@test "check ps 8.0.31 source" {
+  execute_test --product ps --version 8.0.31 --source
+}
+@test "check ps 8.0.31-23 source" {
+  execute_test --product ps --version 8.0.31-23 --source
+}
+
 @test "check pxc 5.7" {
-  run ./get_download_link.sh --product pxc --version 5.7
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxc --version 5.7
+}
+@test "check pxc 5.7.37" {
+  execute_test --product pxc --version 5.7.37
+}
+@test "check pxc 5.7.37-31" {
+  execute_test --product pxc --version 5.7.37-31
+}
+@test "check pxc 5.7.37-31.57" {
+  execute_test --product pxc --version 5.7.37-31.57
 }
 @test "check pxc 8.0" {
-  run ./get_download_link.sh --product pxc --version 8.0
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxc --version 8.0
+}
+@test "check pxc 8.0.21" {
+  execute_test --product pxc --version 8.0.21
+}
+@test "check pxc 8.0.21-12" {
+  execute_test --product pxc --version 8.0.21-12
+}
+@test "check pxc 8.0.31-23.1" {
+  execute_test --product pxc --version 8.0.31-23.1
+}
+@test "check pxc 8.0.31-23.2" {
+  execute_test --product pxc --version 8.0.31-23.2
 }
 @test "check pxc 5.7 source" {
-  run ./get_download_link.sh --product pxc --version 5.7 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxc --version 5.7 --source
+}
+@test "check pxc 5.7.37 source" {
+  execute_test --product pxc --version 5.7.37 --source
+}
+@test "check pxc 5.7.37-31 source" {
+  execute_test --product pxc --version 5.7.37-31 --source
+}
+@test "check pxc 5.7.37-31.57 source" {
+  execute_test --product pxc --version 5.7.37-31.57
 }
 @test "check pxc 8.0 source" {
-  run ./get_download_link.sh --product pxc --version 8.0 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxc --version 8.0 --source
+}
+@test "check pxc 8.0.21 source" {
+  execute_test --product pxc --version 8.0.21 --source
+}
+@test "check pxc 8.0.21-12 source" {
+  execute_test --product pxc --version 8.0.21-12 --source
+}
+
+@test "check proxysql" {
+  execute_test --product proxysql
 }
 
 @test "check psmdb 4.2" {
-  run ./get_download_link.sh --product psmdb --version 4.2
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 4.2
 }
 @test "check psmdb 4.4" {
-  run ./get_download_link.sh --product psmdb --version 4.4
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 4.4
 }
 @test "check psmdb 5.0" {
-  run ./get_download_link.sh --product psmdb --version 5.0
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 5.0
 }
 @test "check psmdb 6.0" {
-  run ./get_download_link.sh --product psmdb --version 6.0
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 6.0
 }
-
+@test "check psmdb 6.0.4" {
+  execute_test --product psmdb --version 6.0.4
+}
+@test "check psmdb 6.0.4-3" {
+  execute_test --product psmdb --version 6.0.4-3
+}
 @test "check psmdb 4.2 source" {
-  run ./get_download_link.sh --product psmdb --version 4.2 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 4.2 --source
 }
 @test "check psmdb 4.4 source" {
-  run ./get_download_link.sh --product psmdb --version 4.4 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 4.4 --source
 }
 @test "check psmdb 5.0 source" {
-  run ./get_download_link.sh --product psmdb --version 5.0 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 5.0 --source
 }
 @test "check psmdb 6.0 source" {
-  run ./get_download_link.sh --product psmdb --version 6.0 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product psmdb --version 6.0 --source
 }
-
 @test "check psmdb 6.0 for jammy" {
-  run ./get_download_link.sh --product psmdb --version 6.0 --distribution jammy
-  [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'glibc2.35')" -eq 1 ]
-  check_file
+  execute_test --product psmdb --version 6.0 --distribution jammy --glibc glibc2.35
 }
 
 @test "check pt" {
-  run ./get_download_link.sh --product pt
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pt
 }
-
+@test "check pt 3.5.1" {
+  execute_test --product pt --version 3.5.1
+}
 @test "check pt source" {
-  run ./get_download_link.sh --product pt --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pt --source
+}
+@test "check pt 3.5.1 source" {
+  execute_test --product pt --version 3.5.1 --source
 }
 
 @test "check pxb 2.4" {
-  run ./get_download_link.sh --product pxb --version 2.4
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxb --version 2.4
+}
+@test "check pxb 2.4.27" {
+  execute_test --product pxb --version 2.4.27
 }
 @test "check pxb 8.0" {
-  run ./get_download_link.sh --product pxb --version 8.0
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxb --version 8.0
 }
-
+@test "check pxb 8.0.30" {
+  execute_test --product pxb --version 8.0.30
+}
+@test "check pxb 8.0.30-23" {
+  execute_test --product pxb --version 8.0.30-23
+}
+@test "check pxb 8.0.32" {
+  execute_test --product pxb --version 8.0.32
+}
+@test "check pxb 8.0.32-25" {
+  execute_test --product pxb --version 8.0.32-25
+}
 @test "check pxb 2.4 source" {
-  run ./get_download_link.sh --product pxb --version 2.4 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxb --version 2.4 --source
+}
+@test "check pxb 2.4.27 source" {
+  execute_test --product pxb --version 2.4.27 --source
 }
 @test "check pxb 8.0 source" {
-  run ./get_download_link.sh --product pxb --version 8.0 --source
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pxb --version 8.0 --source
 }
-
-@test "check pxb 2.4 for centos" {
-  run ./get_download_link.sh --product pxb --version 2.4 --distribution centos
-  [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'glibc2.12')" -eq 1 ]
-  check_file
+@test "check pxb 8.0.32 source" {
+  execute_test --product pxb --version 8.0.32 --source
+}
+@test "check pxb8.0.32-25 source" {
+  execute_test --product pxb --version 8.0.32-25 --source
 }
 @test "check pxb 8.0 for centos" {
-  run ./get_download_link.sh --product pxb --version 8.0 --distribution centos
-  [ "$status" -eq 0 ]
-  [ "$(echo $output | grep -c 'glibc2.17')" -eq 1 ]
-  check_file
+  execute_test --product pxb --version 8.0 --distribution centos --glibc glibc2.17
 }
 
 @test "check pmm-client" {
-  run ./get_download_link.sh --product pmm-client
-  [ "$status" -eq 0 ]
-  check_file
+  execute_test --product pmm-client
+}
+@test "check pmm-client 2.33" {
+  execute_test --product pmm-client --version 2.33
+}
+@test "check pmm-client 2.34.0" {
+  execute_test --product pmm-client --version 2.34.0
+}
+@test "check pmm-client source" {
+  execute_test --product pmm-client --source
+}
+@test "check pmm-client 2.33 source" {
+  execute_test --product pmm-client --version 2.33 --source
+}
+@test "check pmm-client 2.33 source" {
+  execute_test --product pmm-client --version 2.34.0 --source
 }
 
-@test "check pmm-client source" {
-  run ./get_download_link.sh --product pmm-client --source
-  [ "$status" -eq 0 ]
-  check_file
+@test "check mysql 5.7" {
+  execute_test --product mysql --version 5.7
+}
+@test "check mysql 8.0" {
+  execute_test --product mysql --version 8.0
+}
+@test "check mysql 5.7 source" {
+  execute_test --product mysql --version 5.7 --source
+}
+@test "check mysql 8.0 source" {
+  execute_test --product mysql --version 8.0 --source
+}
+
+@test "check mariadb 10.2" {
+  execute_test --product mariadb --version 10.2
+}
+@test "check mariadb 10.3" {
+  execute_test --product mariadb --version 10.3
+}
+@test "check mariadb 10.4" {
+  execute_test --product mariadb --version 10.4
+}
+@test "check mariadb 10.9" {
+  execute_test --product mariadb --version 10.9
+}
+@test "check mariadb 10.10" {
+  execute_test --product mariadb --version 10.10
+}
+@test "check mariadb 10.2 source" {
+  execute_test --product mariadb --version 10.2 --source
+}
+@test "check mariadb 10.3 source" {
+  execute_test --product mariadb --version 10.3 --source
+}
+@test "check mariadb 10.4 source" {
+  execute_test --product mariadb --version 10.4 --source
+}
+@test "check mariadb 10.9 source" {
+  execute_test --product mariadb --version 10.9 --source
+}
+@test "check mariadb 10.10 source" {
+  execute_test --product mariadb --version 10.10 --source
+}
+@test "check mongodb 4.2" {
+  execute_test --product mongodb --version 4.2 --distribution rhel70
+}
+@test "check mongodb 4.4" {
+  execute_test --product mongodb --version 4.4 --distribution debian10
+}
+@test "check mongodb 5.0" {
+  execute_test --product mongodb --version 5.0 --distribution ubuntu2004
+}
+@test "check mongodb 6.0" {
+  execute_test --product mongodb --version 6.0  --distribution amazon2
+}
+@test "check mongodb 4.2 source" {
+  execute_test --product mongodb --version 4.2 --source
+}
+@test "check mongodb 4.4 source" {
+  execute_test --product mongodb --version 4.4 --source
+}
+@test "check mongodb 5.0 source" {
+  execute_test --product mongodb --version 5.0 --source
+}
+@test "check mongodb 6.0 source" {
+  execute_test --product mongodb --version 6.0 --source
+}
+
+@test "check proxysql 1.4" {
+  execute_test --product proxysql --version 1.4
+}
+@test "check proxysql 1.4.14" {
+  execute_test --product proxysql --version 1.4.14
+}
+@test "check proxysql source" {
+  execute_test --product proxysql -s
+}
+@test "check proxysql 1.4 source" {
+  execute_test --product  proxysql --version 1.4 -s
+}
+@test "check proxysql 1.4.14 source" {
+  execute_test --product proxysql --version 1.4.14 -s
+}
+@test "check proxysql2" {
+  execute_test --product proxysql
+}
+@test "check proxysql2 2.4" {
+  execute_test --product proxysql2 --version 2.4
+}
+@test "check proxysql2 2.4.8" {
+  execute_test --product proxysql2 --version 2.4.8
+}
+@test "check proxysql2 2.5" {
+  execute_test --product proxysql2 --version 2.5
+}
+@test "check proxysql2 2.5.2" {
+  execute_test --product proxysql2 --version 2.5.2
+}
+@test "check proxysql2 source" {
+  execute_test --product proxysql2 -s
+}
+@test "check proxysql2 2.4 source" {
+  execute_test --product proxysql2 --version 2.4 -s
+}
+@test "check proxysql2 2.4.8 source" {
+  execute_test --product proxysql2 --version 2.4.8 -s
+}
+@test "check proxysql2 2.5 source" {
+  execute_test --product proxysql2 --version 2.5 -s
+}
+@test "check proxysql2 2.5.2 source" {
+  execute_test --product proxysql2 --version 2.5.2 -s
+}
+
+@test "check vault" {
+  execute_test --product vault
+}
+
+@test "check postgresql" {
+  execute_test --product postgresql
 }
 
 @test "check mysql 5.5 fails" {
@@ -192,143 +406,4 @@ function  check_file(){
 @test "check mysql 5.6 fails" {
   run ./get_download_link.sh --product mysql --version 5.6
   [ "$status" -eq 1 ]
-}
-
-@test "check mysql 5.7" {
-  run ./get_download_link.sh --product mysql --version 5.7
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mysql 8.0" {
-  run ./get_download_link.sh --product mysql --version 8.0
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check mysql 5.7 source" {
-  run ./get_download_link.sh --product mysql --version 5.7 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mysql 8.0 source" {
-  run ./get_download_link.sh --product mysql --version 8.0 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check mariadb 10.2" {
-  run ./get_download_link.sh --product mariadb --version 10.2
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.3" {
-  run ./get_download_link.sh --product mariadb --version 10.3
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.4" {
-  run ./get_download_link.sh --product mariadb --version 10.4
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.9" {
-  run ./get_download_link.sh --product mariadb --version 10.9
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.10" {
-  run ./get_download_link.sh --product mariadb --version 10.10
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.2 source" {
-  run ./get_download_link.sh --product mariadb --version 10.2 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.3 source" {
-  run ./get_download_link.sh --product mariadb --version 10.3 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.4 source" {
-  run ./get_download_link.sh --product mariadb --version 10.4 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.9 source" {
-  run ./get_download_link.sh --product mariadb --version 10.9 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mariadb 10.10 source" {
-  run ./get_download_link.sh --product mariadb --version 10.10 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check mongodb 4.2" {
-  run ./get_download_link.sh --product mongodb --version 4.2 --distribution rhel70
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mongodb 4.4" {
-  run ./get_download_link.sh --product mongodb --version 4.4 --distribution debian10
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mongodb 5.0" {
-  run ./get_download_link.sh --product mongodb --version 5.0 --distribution ubuntu2004
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mongodb 6.0" {
-  run ./get_download_link.sh --product mongodb --version 6.0  --distribution amazon2
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check mongodb 4.2 source" {
-  run ./get_download_link.sh --product mongodb --version 4.2 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mongodb 4.4 source" {
-  run ./get_download_link.sh --product mongodb --version 4.4 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mongodb 5.0 source" {
-  run ./get_download_link.sh --product mongodb --version 5.0 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-@test "check mongodb 6.0 source" {
-  run ./get_download_link.sh --product mongodb --version 6.0 --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check proxysql" {
-  run ./get_download_link.sh --product proxysql
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check proxysql source" {
-  run ./get_download_link.sh --product proxysql --source
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check vault" {
-  run ./get_download_link.sh --product vault
-  [ "$status" -eq 0 ]
-  check_file
-}
-
-@test "check postgresql" {
-  run ./get_download_link.sh --product postgresql
-  [ "$status" -eq 0 ]
-  check_file
 }


### PR DESCRIPTION
Hi,

Tests check passed fine:
$ ./get_download_link_test.bats 
 ✓ check ps 5.6
 ✓ check ps 5.6.49
 ✓ check ps 5.6.49-89
 ✓ check ps 5.6.49-89.0
 ✓ check ps 5.7
 ✓ check ps 5.7.37
 ✓ check ps 5.7.37-40
 ✓ check ps 8.0
 ✓ check ps 8.0.31
 ✓ check ps 8.0.31-23
 ✓ check ps for centos
 ✓ check ps for ubuntu bionic
 ✓ check ps for ubuntu jammy
 ✓ check ps 5.6 source
 ✓ check ps 5.6.49 source
 ✓ check ps 5.6.49-89 source
 ✓ check ps 5.6.49-89.0 source
 ✓ check ps 5.7 source
 ✓ check ps 5.7.37 source
 ✓ check ps 5.7.37-40
 ✓ check ps 8.0 source
 ✓ check ps 8.0.31 source
 ✓ check ps 8.0.31-23 source
 ✓ check pxc 5.7
 ✓ check pxc 5.7.37
 ✓ check pxc 5.7.37-31
 ✓ check pxc 5.7.37-31.57
 ✓ check pxc 8.0
 ✓ check pxc 8.0.21
 ✓ check pxc 8.0.21-12
 ✓ check pxc 8.0.31-23.1
 ✓ check pxc 8.0.31-23.2
 ✓ check pxc 5.7 source
 ✓ check pxc 5.7.37 source
 ✓ check pxc 5.7.37-31 source
 ✓ check pxc 5.7.37-31.57 source
 ✓ check pxc 8.0 source
 ✓ check pxc 8.0.21 source
 ✓ check pxc 8.0.21-12 source
 ✓ check proxysql
 ✓ check psmdb 4.2
 ✓ check psmdb 4.4
 ✓ check psmdb 5.0
 ✓ check psmdb 6.0
 ✓ check psmdb 6.0.4
 ✓ check psmdb 6.0.4-3
 ✓ check psmdb 4.2 source
 ✓ check psmdb 4.4 source
 ✓ check psmdb 5.0 source
 ✓ check psmdb 6.0 source
 ✓ check psmdb 6.0 for jammy
 ✓ check pt
 ✓ check pt 3.5.1
 ✓ check pt source
 ✓ check pt 3.5.1 source
 ✓ check pxb 2.4
 ✓ check pxb 2.4.27
 ✓ check pxb 8.0
 ✓ check pxb 8.0.30
 ✓ check pxb 8.0.30-23
 ✓ check pxb 8.0.32
 ✓ check pxb 8.0.32-25
 ✓ check pxb 2.4 source
 ✓ check pxb 2.4.27 source
 ✓ check pxb 8.0 source
 ✓ check pxb 8.0.32 source
 ✓ check pxb8.0.32-25 source
 ✓ check pxb 8.0 for centos
 ✓ check pmm-client
 ✓ check pmm-client 2.33
 ✓ check pmm-client 2.34.0
 ✓ check pmm-client source
 ✓ check pmm-client 2.33 source
 ✓ check pmm-client 2.33 source
 ✓ check mysql 5.7
 ✓ check mysql 8.0
 ✓ check mysql 5.7 source
 ✓ check mysql 8.0 source
 ✓ check mariadb 10.2
 ✓ check mariadb 10.3
 ✓ check mariadb 10.4
 ✓ check mariadb 10.9
 ✓ check mariadb 10.10
 ✓ check mariadb 10.2 source
 ✓ check mariadb 10.3 source
 ✓ check mariadb 10.4 source
 ✓ check mariadb 10.9 source
 ✓ check mariadb 10.10 source
 ✓ check mongodb 4.2
 ✓ check mongodb 4.4
 ✓ check mongodb 5.0
 ✓ check mongodb 6.0
 ✓ check mongodb 4.2 source
 ✓ check mongodb 4.4 source
 ✓ check mongodb 5.0 source
 ✓ check mongodb 6.0 source
 ✓ check proxysql 1.4
 ✓ check proxysql 1.4.14
 ✓ check proxysql source
 ✓ check proxysql 1.4 source
 ✓ check proxysql 1.4.14 source
 ✓ check proxysql2
 ✓ check proxysql2 2.4
 ✓ check proxysql2 2.4.8
 ✓ check proxysql2 2.5
 ✓ check proxysql2 2.5.2
 ✓ check proxysql2 source
 ✓ check proxysql2 2.4 source
 ✓ check proxysql2 2.4.8 source
 ✓ check proxysql2 2.5 source
 ✓ check proxysql2 2.5.2 source
 ✓ check vault
 ✓ check postgresql
 ✓ check mysql 5.5 fails
 ✓ check mysql 5.6 fails

115 tests, 0 failures
