### PR TITLE
tests: install percona-release rpm before use on RHEL family

### DIFF
--- a/postgresql/automation/wrapper/common.sh
+++ b/postgresql/automation/wrapper/common.sh
@@ -212,6 +212,7 @@ install_pgbackrest() {
         sudo apt-get install -y percona-pgbackrest
     elif [ -f /etc/redhat-release ]; then
 	wget -q https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+	sudo yum install -y ./percona-release-latest.noarch.rpm
 	sudo percona-release enable-only ppg-18
 	sudo yum install -y percona-pgbackrest
     fi


### PR DESCRIPTION
install_pgbackrest() downloaded percona-release-latest.noarch.rpm on RHEL/OL/Rocky but never installed it before calling , so the command failed with 'percona-release: command not found' and percona-pgbackrest was never installed.