### PR TITLE
Improved error handling in replication status checks to accommodate changes in MySQL versions

### DIFF
--- a/randgen/conf/replication/README.md
+++ b/randgen/conf/replication/README.md
@@ -1,0 +1,99 @@
+# Replication Testing
+
+Grammars in this directory drive `runall-new.pl`'s built-in master/slave
+replication mode: one grammar runs against a master, statements replicate to
+a slave, and `runall-new.pl` diffs both servers' data at the end.
+
+## Grammars
+
+| Grammar | Gendata | What it exercises |
+|---|---|---|
+| `replication_simple.yy` | `replication_single_engine.zz` | Plain UPDATE/INSERT/DELETE against standard `--gendata` tables. Good first smoke test. |
+| `replication.yy` | `replication_single_engine.zz` | DDL (`CREATE TRIGGER`/`EVENT`/`PROCEDURE`), manual `SET BINLOG_FORMAT` switching around risky statements, `ROLLBACK TO SAVEPOINT`, recursive procedure calls, background `EVENT`s that fire independently of the query loop. Deliberately adversarial. |
+| `replication_basic.yy`, `rpl_transactions.yy`, `replication-ddl_sql.yy`, `replication-dml_sql.yy`, `WL5092_sql_*.yy` | matching `.zz` in this dir | Other replication-focused scenarios; not covered by the testing below but follow the same invocation pattern. |
+
+## Running a test
+
+`--rpl_mode` is required to actually get a master+slave pair — without it
+`runall-new.pl` just runs a single standalone server.
+
+```bash
+perl runall-new.pl \
+  --basedir=<percona-or-mysql-basedir> \
+  --vardir1=/tmp/rqg_var_rpl_master \
+  --vardir2=/tmp/rqg_var_rpl_slave \
+  --rpl_mode=row \
+  --grammar=conf/replication/replication_simple.yy \
+  --gendata=conf/replication/replication_single_engine.zz \
+  --threads=2 \
+  --queries=500 \
+  --duration=120 \
+  --validators=ReplicationSlaveStatus \
+  --reporter=Backtrace,ErrorLog,QueryTimeout
+```
+
+`--validators=ReplicationSlaveStatus` checks slave health (`Last_Error`/
+`Last_IO_Error`/`Last_SQL_Error`) during the run, not just at the end.
+
+On success, `runall-new.pl` waits for the slave to catch up and diffs a
+`mysqldump` of both servers, printing `No differences were found between
+servers.` For extra confidence beyond that dump diff, verify independently:
+
+```bash
+mysql -h127.0.0.1 -P<slave_port> -uroot -e "SHOW REPLICA STATUS\G" \
+  | grep -E "Exec_Source_Log_Pos|Read_Source_Log_Pos|Last_.*Error"
+mysql -h127.0.0.1 -P<port> -uroot <db> -e "CHECKSUM TABLE <table>;"
+```
+`Read_Source_Log_Pos == Exec_Source_Log_Pos` with empty error fields, plus
+matching checksums on both servers, is the strongest confirmation that the
+slave genuinely applied the same changes -- not just that a summary diff
+happened to match.
+
+## `--rpl_mode`: row / statement / mixed
+
+- **row** (recommended default) -- slave applies row images from the
+  binlog, never re-executes SQL text. Safe against non-deterministic
+  functions by construction.
+- **statement** -- slave re-executes the actual SQL. More revealing (catches
+  real divergence bugs row-based replication is immune to), but grammars
+  using `RAND()`/`UUID()`/etc. need their own safety handling.
+  `replication.yy`'s manual `SET BINLOG_FORMAT='ROW'` wrapping around risky
+  statements is exactly that -- and it does not work under a pure
+  `statement` global default (see below).
+- **mixed** -- statement by default, automatically/manually switches to row
+  for whatever needs it. `replication.yy` requires this or `row`; it fails
+  under pure `statement` mode with a real, reproducible error:
+  `Cannot execute statement: impossible to write to binary log since
+  statement is in row format and BINLOG_FORMAT = STATEMENT` -- the grammar's
+  manual row-format override conflicts with a slave that also binlogs and is
+  globally pinned to statement format. This is expected, not a harness bug.
+
+## Version compatibility
+
+MySQL/Percona 8.0.23 introduced `REPLICA`/`SOURCE` replication terminology as
+accepted aliases for the original `SLAVE`/`MASTER` terms; 8.4.0 removed the
+original terms outright (`STOP SLAVE`, `CHANGE MASTER TO`, `SHOW MASTER
+STATUS`, `SHOW SLAVE STATUS`, `SHOW SLAVE HOSTS`, `MASTER_POS_WAIT()` are hard
+syntax errors from 8.4 onward). MariaDB never made this change. All
+replication-related code in this repo (`ReplMySQLd.pm`, the replication
+Reporters/Validators, `runall.pl`/`runall-new.pl`) selects the correct
+vocabulary per-server via `GenTest::ReplicationTerms`, based on the
+connected server's version string -- no manual flag needed either way.
+
+## Known issue: `CloneSlave` / `CloneSlaveXtrabackup` reporters
+
+Not exercised by the testing above, and currently broken on modern MySQL/
+Percona: `CloneSlave::monitor()` creates the cloned slave's datadir with a
+bare `mkdir()` and starts `mysqld` directly against it, with no
+`--initialize-insecure` bootstrap step. MySQL 8.0+ requires that step before
+a normal startup will succeed against an empty datadir; confirmed failure:
+`InnoDB: File ./ibdata1: 'open' returned OS error 71`. Avoid
+`--reporter=CloneSlave`/`CloneSlaveXtrabackup` until this is fixed.
+
+## Other gotcha
+
+Don't combine `--reporter=Shutdown` with `--rpl_mode`. The `Shutdown`
+reporter tears down both servers as its own coverage check, which can race
+with `runall-new.pl`'s own post-run master/slave comparison (which needs
+both connections alive). The comparison step already handles clean shutdown
+itself -- `Shutdown` is redundant here, not complementary.

--- a/randgen/conf/replication/README.md
+++ b/randgen/conf/replication/README.md
@@ -70,15 +70,46 @@ happened to match.
 
 ## Version compatibility
 
-MySQL/Percona 8.0.23 introduced `REPLICA`/`SOURCE` replication terminology as
-accepted aliases for the original `SLAVE`/`MASTER` terms; 8.4.0 removed the
-original terms outright (`STOP SLAVE`, `CHANGE MASTER TO`, `SHOW MASTER
+MySQL/Percona introduced `REPLICA`/`SOURCE` replication terminology as
+accepted aliases for the original `SLAVE`/`MASTER` terms, then later removed
+the original terms outright (`STOP SLAVE`, `CHANGE MASTER TO`, `SHOW MASTER
 STATUS`, `SHOW SLAVE STATUS`, `SHOW SLAVE HOSTS`, `MASTER_POS_WAIT()` are hard
-syntax errors from 8.4 onward). MariaDB never made this change. All
+syntax errors on current versions). MariaDB never made this change. All
 replication-related code in this repo (`ReplMySQLd.pm`, the replication
 Reporters/Validators, `runall.pl`/`runall-new.pl`) selects the correct
 vocabulary per-server via `GenTest::ReplicationTerms`, based on the
 connected server's version string -- no manual flag needed either way.
+
+Not every statement and function in that rename landed in the same server
+release. The bulk of the new vocabulary (the `SHOW REPLICA STATUS`-style
+statements, `CHANGE REPLICATION SOURCE TO`, `START`/`STOP REPLICA`) shipped
+together, but a couple of individual pieces -- the binlog-status query and
+the position-wait function -- were confirmed by testing against real servers
+to lag behind on a later point release, while everything else already
+worked. `GenTest::ReplicationTerms` gates those specific terms on their own
+boundary rather than assuming the whole rollout is atomic. If a replication
+run against a new server version starts failing with a "does not exist" or
+syntax error on a name this module emits, that's the first thing to check --
+the affected term likely needs its own boundary rather than sharing an
+existing one, and the fix should be confirmed against a real server of that
+version rather than assumed from release notes alone.
+
+## `ReplicationThreadRestarter` reporter
+
+Periodically issues a random `START`/`STOP` against the replica's IO thread,
+SQL thread, both, or neither, independent of anything else going on in the
+test. It's useful for exercising how replication behaves when it's toggled
+mid-run rather than left running continuously throughout.
+
+It's deliberately adversarial toward validators that assert the replica's
+SQL thread is currently running (`ReplicationSlaveStatus`,
+`ReplicationWaitForSlave`) -- pairing them can produce a
+`STATUS_REPLICATION_FAILURE` that just reflects the validator catching the
+replica mid-toggle, not a real bug. Check the general log for the actual
+`START`/`STOP` statements the reporter sent (and whether they succeeded)
+before concluding a failure from that combination means something is
+actually broken. Run it alongside reporters/validators that don't assert
+thread state if the goal is to test the toggling itself in isolation.
 
 ## Known issue: `CloneSlave` / `CloneSlaveXtrabackup` reporters
 

--- a/randgen/lib/DBServer/MySQL/MySQLd.pm
+++ b/randgen/lib/DBServer/MySQL/MySQLd.pm
@@ -614,9 +614,19 @@ sub running {
         ## non-working solution for unix....
         return -f $self->pidfile;
     } else {
-        ## Check if the child process is active.
-        my $child_status = waitpid($self->serverpid,WNOHANG);
-        return $child_status != -1;
+        return 0 if not defined $self->serverpid;
+        # waitpid() only reports on direct children. The command in
+        # startServer() is exec()'d as a single string with I/O redirection,
+        # so Perl invokes it via "/bin/sh -c ..."; some shells (e.g. dash,
+        # confirmed on this class of system) fork a child for the redirected
+        # command instead of exec-replacing themselves, leaving the actual
+        # mysqld process a grandchild rather than a direct child. waitpid()
+        # then always returns ECHILD for it -- even while it's fully alive --
+        # which made this always report "not running" and left stopServer()
+        # believing shutdown succeeded before it actually had, orphaning the
+        # server process once the caller exits. Checking for the process's
+        # existence directly is independent of the parent/child relationship.
+        return kill(0, $self->serverpid) ? 1 : 0;
     }
 }
 

--- a/randgen/lib/DBServer/MySQL/ReplMySQLd.pm
+++ b/randgen/lib/DBServer/MySQL/ReplMySQLd.pm
@@ -32,15 +32,15 @@ use Data::Dumper;
 use GenTest::ReplicationTerms qw(replicationTerms);
 
 use constant REPLMYSQLD_BASEDIR => 0;
-use constant REPLMYSQLD_MASTER_VARDIR => 1;
-use constant REPLMYSQLD_SLAVE_VARDIR => 2;
-use constant REPLMYSQLD_MASTER_PORT => 3;
-use constant REPLMYSQLD_SLAVE_PORT => 4;
+use constant REPLMYSQLD_SOURCE_VARDIR => 1;
+use constant REPLMYSQLD_REPLICA_VARDIR => 2;
+use constant REPLMYSQLD_SOURCE_PORT => 3;
+use constant REPLMYSQLD_REPLICA_PORT => 4;
 use constant REPLMYSQLD_MODE => 5;
 use constant REPLMYSQLD_START_DIRTY => 6;
 use constant REPLMYSQLD_SERVER_OPTIONS => 7;
-use constant REPLMYSQLD_MASTER => 8;
-use constant REPLMYSQLD_SLAVE => 9;
+use constant REPLMYSQLD_SOURCE => 8;
+use constant REPLMYSQLD_REPLICA => 9;
 use constant REPLMYSQLD_VALGRIND => 10;
 use constant REPLMYSQLD_VALGRIND_OPTIONS => 11;
 use constant REPLMYSQLD_GENERAL_LOG => 12;
@@ -50,121 +50,121 @@ use constant REPLMYSQLD_TERMS => 14;
 sub new {
     my $class = shift;
 
-    my $self = $class->SUPER::new({'master' => REPLMYSQLD_MASTER,
-                                   'slave' => REPLMYSQLD_SLAVE,
+    my $self = $class->SUPER::new({'source' => REPLMYSQLD_SOURCE,
+                                   'replica' => REPLMYSQLD_REPLICA,
                                    'basedir' => REPLMYSQLD_BASEDIR,
                                    'debug_server' => REPLMYSQLD_DEBUG_SERVER,
-                                   'master_vardir' => REPLMYSQLD_MASTER_VARDIR,
-                                   'master_port' => REPLMYSQLD_MASTER_PORT,
-                                   'slave_vardir' => REPLMYSQLD_SLAVE_VARDIR,
-                                   'slave_port' => REPLMYSQLD_SLAVE_PORT,
+                                   'source_vardir' => REPLMYSQLD_SOURCE_VARDIR,
+                                   'source_port' => REPLMYSQLD_SOURCE_PORT,
+                                   'replica_vardir' => REPLMYSQLD_REPLICA_VARDIR,
+                                   'replica_port' => REPLMYSQLD_REPLICA_PORT,
                                    'mode' => REPLMYSQLD_MODE,
                                    'server_options' => REPLMYSQLD_SERVER_OPTIONS,
                                    'general_log' => REPLMYSQLD_GENERAL_LOG,
                                    'start_dirty' => REPLMYSQLD_START_DIRTY,
                                    'valgrind' => REPLMYSQLD_VALGRIND,
                                    'valgrind_options', REPLMYSQLD_VALGRIND_OPTIONS},@_);
-    
-    if (defined $self->master || defined $self->slave) {
+
+    if (defined $self->source || defined $self->replica) {
         ## Repl pair defined from two predefined servers
 
-        if (not (defined $self->master && defined $self->slave)) {
-            croak("Both master and slave must be defined");
+        if (not (defined $self->source && defined $self->replica)) {
+            croak("Both source and replica must be defined");
         }
-        $self->master->addServerOptions(["--server_id=1",
+        $self->source->addServerOptions(["--server_id=1",
                                          "--log-bin=mysql-bin",
                                          "--report-host=127.0.0.1",
-                                         "--report_port=".$self->master->port]);
-        $self->slave->addServerOptions(["--server_id=2",
+                                         "--report_port=".$self->source->port]);
+        $self->replica->addServerOptions(["--server_id=2",
                                         "--report-host=127.0.0.1",
-                                        "--report_port=".$self->slave->port]);
+                                        "--report_port=".$self->replica->port]);
     } else {
         ## Repl pair defined from parameters. The servers have the same basedir (is of the same version)
-        if (not defined $self->[REPLMYSQLD_MASTER_PORT]) {
-            $self->[REPLMYSQLD_MASTER_PORT] = DBServer::MySQL::MySQLd::MYSQLD_DEFAULT_PORT;
+        if (not defined $self->[REPLMYSQLD_SOURCE_PORT]) {
+            $self->[REPLMYSQLD_SOURCE_PORT] = DBServer::MySQL::MySQLd::MYSQLD_DEFAULT_PORT;
         }
-    
-        if (not defined $self->[REPLMYSQLD_SLAVE_PORT]) {
-            $self->[REPLMYSQLD_SLAVE_PORT] = $self->[REPLMYSQLD_MASTER_PORT] + 2;        
+
+        if (not defined $self->[REPLMYSQLD_REPLICA_PORT]) {
+            $self->[REPLMYSQLD_REPLICA_PORT] = $self->[REPLMYSQLD_SOURCE_PORT] + 2;
         }
 
         if (not defined $self->[REPLMYSQLD_MODE]) {
             $self->[REPLMYSQLD_MODE] = 'default';
         }
-    
-        if (not defined $self->[REPLMYSQLD_MASTER_VARDIR]) {
-            $self->[REPLMYSQLD_MASTER_VARDIR] = "mysql-test/var";
+
+        if (not defined $self->[REPLMYSQLD_SOURCE_VARDIR]) {
+            $self->[REPLMYSQLD_SOURCE_VARDIR] = "mysql-test/var";
         }
-        if (not defined $self->[REPLMYSQLD_SLAVE_VARDIR]) {
-            my $varbase = $self->[REPLMYSQLD_MASTER_VARDIR];
+        if (not defined $self->[REPLMYSQLD_REPLICA_VARDIR]) {
+            my $varbase = $self->[REPLMYSQLD_SOURCE_VARDIR];
             $varbase =~ s/(.*)\/$/\1/;
-            $self->[REPLMYSQLD_SLAVE_VARDIR] = $varbase.'_slave';
+            $self->[REPLMYSQLD_REPLICA_VARDIR] = $varbase.'_slave';
         }
-        
-        my @master_options;
-        push(@master_options, 
+
+        my @source_options;
+        push(@source_options,
              "--server_id=1",
              "--log-bin=mysql-bin",
              "--report-host=127.0.0.1",
-             "--report_port=".$self->[REPLMYSQLD_MASTER_PORT]);
+             "--report_port=".$self->[REPLMYSQLD_SOURCE_PORT]);
         if (defined $self->[REPLMYSQLD_SERVER_OPTIONS]) {
-            push(@master_options, 
+            push(@source_options,
                  @{$self->[REPLMYSQLD_SERVER_OPTIONS]});
         }
-        
-        
-        $self->[REPLMYSQLD_MASTER] = 
+
+
+        $self->[REPLMYSQLD_SOURCE] =
         DBServer::MySQL::MySQLd->new(basedir => $self->[REPLMYSQLD_BASEDIR],
-                                     vardir => $self->[REPLMYSQLD_MASTER_VARDIR],
-                                     debug_server => $self->[REPLMYSQLD_DEBUG_SERVER],                
-                                     port => $self->[REPLMYSQLD_MASTER_PORT],
-                                     server_options => \@master_options,
+                                     vardir => $self->[REPLMYSQLD_SOURCE_VARDIR],
+                                     debug_server => $self->[REPLMYSQLD_DEBUG_SERVER],
+                                     port => $self->[REPLMYSQLD_SOURCE_PORT],
+                                     server_options => \@source_options,
                                      general_log => $self->[REPLMYSQLD_GENERAL_LOG],
                                      start_dirty => $self->[REPLMYSQLD_START_DIRTY],
                                      valgrind => $self->[REPLMYSQLD_VALGRIND],
                                      valgrind_options => $self->[REPLMYSQLD_VALGRIND_OPTIONS]);
-        
-        if (not defined $self->master) {
-            croak("Could not create master");
+
+        if (not defined $self->source) {
+            croak("Could not create source");
         }
-        
-        my @slave_options;
-        push(@slave_options, 
+
+        my @replica_options;
+        push(@replica_options,
              "--server_id=2",
              "--report-host=127.0.0.1",
-             "--report_port=".$self->[REPLMYSQLD_SLAVE_PORT]);
+             "--report_port=".$self->[REPLMYSQLD_REPLICA_PORT]);
         if (defined $self->[REPLMYSQLD_SERVER_OPTIONS]) {
-            push(@slave_options, 
+            push(@replica_options,
                  @{$self->[REPLMYSQLD_SERVER_OPTIONS]});
         }
-        
-        
-        $self->[REPLMYSQLD_SLAVE] = 
+
+
+        $self->[REPLMYSQLD_REPLICA] =
         DBServer::MySQL::MySQLd->new(basedir => $self->[REPLMYSQLD_BASEDIR],
-                                     vardir => $self->[REPLMYSQLD_SLAVE_VARDIR],
-                                     debug_server => $self->[REPLMYSQLD_DEBUG_SERVER],                
-                                     port => $self->[REPLMYSQLD_SLAVE_PORT],
-                                     server_options => \@slave_options,
+                                     vardir => $self->[REPLMYSQLD_REPLICA_VARDIR],
+                                     debug_server => $self->[REPLMYSQLD_DEBUG_SERVER],
+                                     port => $self->[REPLMYSQLD_REPLICA_PORT],
+                                     server_options => \@replica_options,
                                      general_log => $self->[REPLMYSQLD_GENERAL_LOG],
                                      start_dirty => $self->[REPLMYSQLD_START_DIRTY],
                                      valgrind => $self->[REPLMYSQLD_VALGRIND],
                                      valgrind_options => $self->[REPLMYSQLD_VALGRIND_OPTIONS]);
-        
-        if (not defined $self->slave) {
-            $self->master->stopServer;
-            croak("Could not create slave");
+
+        if (not defined $self->replica) {
+            $self->source->stopServer;
+            croak("Could not create replica");
         }
     }
-    
+
     return $self;
 }
 
-sub master {
-    return $_[0]->[REPLMYSQLD_MASTER];
+sub source {
+    return $_[0]->[REPLMYSQLD_SOURCE];
 }
 
-sub slave {
-    return $_[0]->[REPLMYSQLD_SLAVE];
+sub replica {
+    return $_[0]->[REPLMYSQLD_REPLICA];
 }
 
 sub mode {
@@ -174,69 +174,69 @@ sub mode {
 sub startServer {
     my ($self) = @_;
 
-    $self->master->startServer;
-    my $master_dbh = $self->master->dbh;
-    $self->slave->startServer;
-    my $slave_dbh = $self->slave->dbh;
+    $self->source->startServer;
+    my $source_dbh = $self->source->dbh;
+    $self->replica->startServer;
+    my $replica_dbh = $self->replica->dbh;
 
-	my ($foo, $master_version) = $master_dbh->selectrow_array("SHOW VARIABLES LIKE 'version'");
+	my ($foo, $source_version) = $source_dbh->selectrow_array("SHOW VARIABLES LIKE 'version'");
 
-	if (($master_version !~ m{^5\.0}sio) && ($self->mode ne 'default')) {
-		$master_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
-		$slave_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
+	if (($source_version !~ m{^5\.0}sio) && ($self->mode ne 'default')) {
+		$source_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
+		$replica_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
 	}
 
-	my $terms = replicationTerms($master_version);
+	my $terms = replicationTerms($source_version);
 	$self->[REPLMYSQLD_TERMS] = $terms;
 
-	$slave_dbh->do($terms->{stop_replica});
+	$replica_dbh->do($terms->{stop_replica});
 
-#	$slave_dbh->do("SET GLOBAL storage_engine = '$engine'") if defined $engine;
+#	$replica_dbh->do("SET GLOBAL storage_engine = '$engine'") if defined $engine;
 
-	$slave_dbh->do($terms->{change_source}.
-                   " ".$terms->{source_port}." = ".$self->master->port.",".
+	$replica_dbh->do($terms->{change_source}.
+                   " ".$terms->{source_port}." = ".$self->source->port.",".
                    " ".$terms->{source_host}." = '127.0.0.1',".
                    " ".$terms->{source_user}." = 'root',".
                    " ".$terms->{source_connect_retry}." = 1");
 
-	$slave_dbh->do($terms->{start_replica});
+	$replica_dbh->do($terms->{start_replica});
 
     return DBSTATUS_OK;
 }
 
-sub waitForSlaveSync {
+sub waitForReplicaSync {
     my ($self) = @_;
     # Fall back to legacy only if startServer() never ran (should be rare).
     my $terms = $self->[REPLMYSQLD_TERMS] || replicationTerms(undef);
 
     # A reporter such as "Shutdown" can legitimately terminate the servers
     # as its own coverage check before GenTest::App::GenTest returns, and
-    # runall-new.pl's post-run master/slave comparison calls this
+    # runall-new.pl's post-run source/replica comparison calls this
     # unconditionally whenever --rpl_mode is set, with no way to know that
     # already happened. Fail clearly rather than crashing the whole process
     # on ->selectrow_array against an undef/disconnected dbh.
-    my $master_dbh = $self->master->dbh;
-    if (not defined $master_dbh) {
-        say("waitForSlaveSync: master connection is gone (server already stopped?), cannot compare.");
+    my $source_dbh = $self->source->dbh;
+    if (not defined $source_dbh) {
+        say("waitForReplicaSync: source connection is gone (server already stopped?), cannot compare.");
         return DBSTATUS_FAILURE;
     }
 
-    my ($file, $pos) = $master_dbh->selectrow_array($terms->{binlog_status});
-    say("master status $file/$pos");
+    my ($file, $pos) = $source_dbh->selectrow_array($terms->{binlog_status});
+    say("source status $file/$pos");
 
-    my $slave_dbh = $self->slave->dbh;
-    if (not defined $slave_dbh) {
-        say("waitForSlaveSync: slave connection is gone (server already stopped?), cannot compare.");
+    my $replica_dbh = $self->replica->dbh;
+    if (not defined $replica_dbh) {
+        say("waitForReplicaSync: replica connection is gone (server already stopped?), cannot compare.");
         return DBSTATUS_FAILURE;
     }
 
-    my $wait_result = $slave_dbh->selectrow_array("SELECT ".$terms->{pos_wait_func}."('$file',$pos)");
+    my $wait_result = $replica_dbh->selectrow_array("SELECT ".$terms->{pos_wait_func}."('$file',$pos)");
     if (not defined $wait_result) {
-        my $slave_status = $slave_dbh->selectrow_hashref($terms->{replica_status});
-        my $err = (defined $slave_status)
-            ? ($slave_status->{Last_SQL_Error} || $slave_status->{Last_Error} || '')
+        my $replica_status = $replica_dbh->selectrow_hashref($terms->{replica_status});
+        my $err = (defined $replica_status)
+            ? ($replica_status->{Last_SQL_Error} || $replica_status->{Last_Error} || '')
             : '';
-        say("Slave SQL thread has stopped with error: ".$err);
+        say("Replica SQL thread has stopped with error: ".$err);
 		return DBSTATUS_FAILURE;
     } else {
         return DBSTATUS_OK;
@@ -247,14 +247,14 @@ sub stopServer {
     my ($self) = @_;
     my $terms = $self->[REPLMYSQLD_TERMS] || replicationTerms(undef);
 
-    $self->waitForSlaveSync();
-    # Same rationale as the guards in waitForSlaveSync(): a prior reporter
-    # (e.g. "Shutdown") may have already stopped the slave.
-    my $slave_dbh = $self->slave->dbh;
-    $slave_dbh->do($terms->{stop_replica}) if defined $slave_dbh;
+    $self->waitForReplicaSync();
+    # Same rationale as the guards in waitForReplicaSync(): a prior reporter
+    # (e.g. "Shutdown") may have already stopped the replica.
+    my $replica_dbh = $self->replica->dbh;
+    $replica_dbh->do($terms->{stop_replica}) if defined $replica_dbh;
 
-    $self->slave->stopServer;
-    $self->master->stopServer;
+    $self->replica->stopServer;
+    $self->source->stopServer;
 
     return DBSTATUS_OK;
 }

--- a/randgen/lib/DBServer/MySQL/ReplMySQLd.pm
+++ b/randgen/lib/DBServer/MySQL/ReplMySQLd.pm
@@ -44,6 +44,60 @@ use constant REPLMYSQLD_VALGRIND => 10;
 use constant REPLMYSQLD_VALGRIND_OPTIONS => 11;
 use constant REPLMYSQLD_GENERAL_LOG => 12;
 use constant REPLMYSQLD_DEBUG_SERVER => 13;
+use constant REPLMYSQLD_TERMS => 14;
+
+# MySQL/Percona 8.0.23 introduced SOURCE/REPLICA replication terminology as
+# accepted aliases for the original MASTER/SLAVE terms, then 8.4.0 removed
+# the original terms outright (STOP SLAVE / CHANGE MASTER TO / START SLAVE /
+# SHOW MASTER STATUS / SHOW SLAVE STATUS / MASTER_POS_WAIT() are hard syntax
+# errors from 8.4 onward, not just deprecation warnings) -- confirmed live
+# against a Percona Server 9.7 build, where every one of those statements is
+# rejected. MariaDB never made this change and only accepts the original
+# terminology at every current version. Picking the wrong vocabulary doesn't
+# degrade gracefully -- it fails replication setup outright before a single
+# grammar query runs -- so detect it from the same version string
+# startServer() already fetches, rather than hardcoding either one.
+my %LEGACY_REPLICATION_TERMS = (
+    stop_replica         => 'STOP SLAVE',
+    change_source         => 'CHANGE MASTER TO',
+    source_port           => 'MASTER_PORT',
+    source_host           => 'MASTER_HOST',
+    source_user           => 'MASTER_USER',
+    source_connect_retry  => 'MASTER_CONNECT_RETRY',
+    start_replica         => 'START SLAVE',
+    binlog_status         => 'SHOW MASTER STATUS',
+    pos_wait_func          => 'MASTER_POS_WAIT',
+    replica_status        => 'SHOW SLAVE STATUS',
+);
+
+my %MODERN_REPLICATION_TERMS = (
+    stop_replica         => 'STOP REPLICA',
+    change_source         => 'CHANGE REPLICATION SOURCE TO',
+    source_port           => 'SOURCE_PORT',
+    source_host           => 'SOURCE_HOST',
+    source_user           => 'SOURCE_USER',
+    source_connect_retry  => 'SOURCE_CONNECT_RETRY',
+    start_replica         => 'START REPLICA',
+    binlog_status         => 'SHOW BINARY LOG STATUS',
+    pos_wait_func          => 'SOURCE_POS_WAIT',
+    replica_status        => 'SHOW REPLICA STATUS',
+);
+
+sub _replicationTerms {
+    my ($version_string) = @_;
+
+    return \%LEGACY_REPLICATION_TERMS if $version_string =~ m{mariadb}sio;
+
+    my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
+    if (defined $major &&
+        (($major > 8) ||
+         ($major == 8 && $minor > 0) ||
+         ($major == 8 && $minor == 0 && $patch >= 23))) {
+        return \%MODERN_REPLICATION_TERMS;
+    }
+
+    return \%LEGACY_REPLICATION_TERMS;
+}
 
 sub new {
     my $class = shift;
@@ -183,29 +237,53 @@ sub startServer {
 		$master_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
 		$slave_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
 	}
-    
-	$slave_dbh->do("STOP SLAVE");
+
+	my $terms = _replicationTerms($master_version);
+	$self->[REPLMYSQLD_TERMS] = $terms;
+
+	$slave_dbh->do($terms->{stop_replica});
 
 #	$slave_dbh->do("SET GLOBAL storage_engine = '$engine'") if defined $engine;
-    
-	$slave_dbh->do("CHANGE MASTER TO ".
-                   " MASTER_PORT = ".$self->master->port.",".
-                   " MASTER_HOST = '127.0.0.1',".
-                   " MASTER_USER = 'root',".
-                   " MASTER_CONNECT_RETRY = 1");
-    
-	$slave_dbh->do("START SLAVE");
-    
+
+	$slave_dbh->do($terms->{change_source}.
+                   " ".$terms->{source_port}." = ".$self->master->port.",".
+                   " ".$terms->{source_host}." = '127.0.0.1',".
+                   " ".$terms->{source_user}." = 'root',".
+                   " ".$terms->{source_connect_retry}." = 1");
+
+	$slave_dbh->do($terms->{start_replica});
+
     return DBSTATUS_OK;
 }
 
 sub waitForSlaveSync {
     my ($self) = @_;
-    my ($file, $pos) = $self->master->dbh->selectrow_array("SHOW MASTER STATUS");
+    my $terms = $self->[REPLMYSQLD_TERMS] || \%LEGACY_REPLICATION_TERMS;
+
+    # A reporter such as "Shutdown" can legitimately terminate the servers
+    # as its own coverage check before GenTest::App::GenTest returns, and
+    # runall-new.pl's post-run master/slave comparison calls this
+    # unconditionally whenever --rpl_mode is set, with no way to know that
+    # already happened. Fail clearly rather than crashing the whole process
+    # on ->selectrow_array against an undef/disconnected dbh.
+    my $master_dbh = $self->master->dbh;
+    if (not defined $master_dbh) {
+        say("waitForSlaveSync: master connection is gone (server already stopped?), cannot compare.");
+        return DBSTATUS_FAILURE;
+    }
+
+    my ($file, $pos) = $master_dbh->selectrow_array($terms->{binlog_status});
     say("master status $file/$pos");
-    my $wait_result = $self->slave->dbh->selectrow_array("SELECT MASTER_POS_WAIT('$file',$pos)");
+
+    my $slave_dbh = $self->slave->dbh;
+    if (not defined $slave_dbh) {
+        say("waitForSlaveSync: slave connection is gone (server already stopped?), cannot compare.");
+        return DBSTATUS_FAILURE;
+    }
+
+    my $wait_result = $slave_dbh->selectrow_array("SELECT ".$terms->{pos_wait_func}."('$file',$pos)");
     if (not defined $wait_result) {
-        my @slave_status = $self->slave->dbh->selectrow_array("SHOW SLAVE STATUS");
+        my @slave_status = $slave_dbh->selectrow_array($terms->{replica_status});
         say("Slave SQL thread has stopped with error: ".$slave_status[37]);
 		return DBSTATUS_FAILURE;
     } else {
@@ -215,10 +293,14 @@ sub waitForSlaveSync {
 
 sub stopServer {
     my ($self) = @_;
+    my $terms = $self->[REPLMYSQLD_TERMS] || \%LEGACY_REPLICATION_TERMS;
 
     $self->waitForSlaveSync();
-    $self->slave->dbh->do("STOP SLAVE");
-    
+    # Same rationale as the guards in waitForSlaveSync(): a prior reporter
+    # (e.g. "Shutdown") may have already stopped the slave.
+    my $slave_dbh = $self->slave->dbh;
+    $slave_dbh->do($terms->{stop_replica}) if defined $slave_dbh;
+
     $self->slave->stopServer;
     $self->master->stopServer;
 

--- a/randgen/lib/DBServer/MySQL/ReplMySQLd.pm
+++ b/randgen/lib/DBServer/MySQL/ReplMySQLd.pm
@@ -29,6 +29,7 @@ use strict;
 
 use Carp;
 use Data::Dumper;
+use GenTest::ReplicationTerms qw(replicationTerms);
 
 use constant REPLMYSQLD_BASEDIR => 0;
 use constant REPLMYSQLD_MASTER_VARDIR => 1;
@@ -45,59 +46,6 @@ use constant REPLMYSQLD_VALGRIND_OPTIONS => 11;
 use constant REPLMYSQLD_GENERAL_LOG => 12;
 use constant REPLMYSQLD_DEBUG_SERVER => 13;
 use constant REPLMYSQLD_TERMS => 14;
-
-# MySQL/Percona 8.0.23 introduced SOURCE/REPLICA replication terminology as
-# accepted aliases for the original MASTER/SLAVE terms, then 8.4.0 removed
-# the original terms outright (STOP SLAVE / CHANGE MASTER TO / START SLAVE /
-# SHOW MASTER STATUS / SHOW SLAVE STATUS / MASTER_POS_WAIT() are hard syntax
-# errors from 8.4 onward, not just deprecation warnings) -- confirmed live
-# against a Percona Server 9.7 build, where every one of those statements is
-# rejected. MariaDB never made this change and only accepts the original
-# terminology at every current version. Picking the wrong vocabulary doesn't
-# degrade gracefully -- it fails replication setup outright before a single
-# grammar query runs -- so detect it from the same version string
-# startServer() already fetches, rather than hardcoding either one.
-my %LEGACY_REPLICATION_TERMS = (
-    stop_replica         => 'STOP SLAVE',
-    change_source         => 'CHANGE MASTER TO',
-    source_port           => 'MASTER_PORT',
-    source_host           => 'MASTER_HOST',
-    source_user           => 'MASTER_USER',
-    source_connect_retry  => 'MASTER_CONNECT_RETRY',
-    start_replica         => 'START SLAVE',
-    binlog_status         => 'SHOW MASTER STATUS',
-    pos_wait_func          => 'MASTER_POS_WAIT',
-    replica_status        => 'SHOW SLAVE STATUS',
-);
-
-my %MODERN_REPLICATION_TERMS = (
-    stop_replica         => 'STOP REPLICA',
-    change_source         => 'CHANGE REPLICATION SOURCE TO',
-    source_port           => 'SOURCE_PORT',
-    source_host           => 'SOURCE_HOST',
-    source_user           => 'SOURCE_USER',
-    source_connect_retry  => 'SOURCE_CONNECT_RETRY',
-    start_replica         => 'START REPLICA',
-    binlog_status         => 'SHOW BINARY LOG STATUS',
-    pos_wait_func          => 'SOURCE_POS_WAIT',
-    replica_status        => 'SHOW REPLICA STATUS',
-);
-
-sub _replicationTerms {
-    my ($version_string) = @_;
-
-    return \%LEGACY_REPLICATION_TERMS if $version_string =~ m{mariadb}sio;
-
-    my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
-    if (defined $major &&
-        (($major > 8) ||
-         ($major == 8 && $minor > 0) ||
-         ($major == 8 && $minor == 0 && $patch >= 23))) {
-        return \%MODERN_REPLICATION_TERMS;
-    }
-
-    return \%LEGACY_REPLICATION_TERMS;
-}
 
 sub new {
     my $class = shift;
@@ -238,7 +186,7 @@ sub startServer {
 		$slave_dbh->do("SET GLOBAL BINLOG_FORMAT = '".$self->mode."'");
 	}
 
-	my $terms = _replicationTerms($master_version);
+	my $terms = replicationTerms($master_version);
 	$self->[REPLMYSQLD_TERMS] = $terms;
 
 	$slave_dbh->do($terms->{stop_replica});
@@ -258,7 +206,8 @@ sub startServer {
 
 sub waitForSlaveSync {
     my ($self) = @_;
-    my $terms = $self->[REPLMYSQLD_TERMS] || \%LEGACY_REPLICATION_TERMS;
+    # Fall back to legacy only if startServer() never ran (should be rare).
+    my $terms = $self->[REPLMYSQLD_TERMS] || replicationTerms(undef);
 
     # A reporter such as "Shutdown" can legitimately terminate the servers
     # as its own coverage check before GenTest::App::GenTest returns, and
@@ -283,8 +232,11 @@ sub waitForSlaveSync {
 
     my $wait_result = $slave_dbh->selectrow_array("SELECT ".$terms->{pos_wait_func}."('$file',$pos)");
     if (not defined $wait_result) {
-        my @slave_status = $slave_dbh->selectrow_array($terms->{replica_status});
-        say("Slave SQL thread has stopped with error: ".$slave_status[37]);
+        my $slave_status = $slave_dbh->selectrow_hashref($terms->{replica_status});
+        my $err = (defined $slave_status)
+            ? ($slave_status->{Last_SQL_Error} || $slave_status->{Last_Error} || '')
+            : '';
+        say("Slave SQL thread has stopped with error: ".$err);
 		return DBSTATUS_FAILURE;
     } else {
         return DBSTATUS_OK;
@@ -293,7 +245,7 @@ sub waitForSlaveSync {
 
 sub stopServer {
     my ($self) = @_;
-    my $terms = $self->[REPLMYSQLD_TERMS] || \%LEGACY_REPLICATION_TERMS;
+    my $terms = $self->[REPLMYSQLD_TERMS] || replicationTerms(undef);
 
     $self->waitForSlaveSync();
     # Same rationale as the guards in waitForSlaveSync(): a prior reporter

--- a/randgen/lib/GenTest/Executor/MySQL.pm
+++ b/randgen/lib/GenTest/Executor/MySQL.pm
@@ -99,11 +99,11 @@ my @patterns = map { qr{$_}i } @errors;
 use constant EXECUTOR_MYSQL_AUTOCOMMIT => 20;
 
 #
-# Column positions for SHOW SLAVES
-# 
+# Column positions for SHOW REPLICAS / SHOW SLAVE HOSTS
+#
 
-use constant SLAVE_INFO_HOST => 1;
-use constant SLAVE_INFO_PORT => 2;
+use constant REPLICA_INFO_HOST => 1;
+use constant REPLICA_INFO_PORT => 2;
 
 #
 # MySQL status codes taken from errmsg.h
@@ -817,15 +817,15 @@ sub replicationTerms {
 	return GenTest::ReplicationTerms::replicationTerms($executor->version());
 }
 
-sub slaveInfo {
+sub replicaInfo {
 	my $executor = shift;
 	my $terms = $executor->replicationTerms();
-	my $slave_info = $executor->dbh()->selectrow_arrayref($terms->{replicas});
-	return ('', '') if not defined $slave_info;
-	return ($slave_info->[SLAVE_INFO_HOST], $slave_info->[SLAVE_INFO_PORT]);
+	my $replica_info = $executor->dbh()->selectrow_arrayref($terms->{replicas});
+	return ('', '') if not defined $replica_info;
+	return ($replica_info->[REPLICA_INFO_HOST], $replica_info->[REPLICA_INFO_PORT]);
 }
 
-sub masterStatus {
+sub sourceStatus {
 	my $executor = shift;
 	my $terms = $executor->replicationTerms();
 	return $executor->dbh()->selectrow_array($terms->{binlog_status});

--- a/randgen/lib/GenTest/Executor/MySQL.pm
+++ b/randgen/lib/GenTest/Executor/MySQL.pm
@@ -803,15 +803,37 @@ sub version {
 	return $dbh->selectrow_array("SELECT VERSION()");
 }
 
+# MySQL/Percona 8.0.23 introduced REPLICA/SOURCE terminology as accepted
+# aliases for the original SLAVE/MASTER replication statements, then 8.4.0
+# removed the original statements outright -- SHOW SLAVE HOSTS and
+# SHOW MASTER STATUS are hard syntax errors from 8.4 onward, not just
+# deprecation warnings (confirmed live against a Percona Server 9.7 build).
+# MariaDB never made this change and only accepts the original statements at
+# every current version. Column layout is unchanged in both renames, only
+# the statement text differs.
+sub _usesModernReplicationSyntax {
+	my ($version_string) = @_;
+	return 0 if not defined $version_string;
+	return 0 if $version_string =~ m{mariadb}sio;
+	my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
+	return 0 if not defined $major;
+	return (($major > 8) ||
+	        ($major == 8 && $minor > 0) ||
+	        ($major == 8 && $minor == 0 && $patch >= 23)) ? 1 : 0;
+}
+
 sub slaveInfo {
 	my $executor = shift;
-	my $slave_info = $executor->dbh()->selectrow_arrayref("SHOW SLAVE HOSTS");
+	my $modern = _usesModernReplicationSyntax($executor->version());
+	my $slave_info = $executor->dbh()->selectrow_arrayref($modern ? "SHOW REPLICAS" : "SHOW SLAVE HOSTS");
+	return ('', '') if not defined $slave_info;
 	return ($slave_info->[SLAVE_INFO_HOST], $slave_info->[SLAVE_INFO_PORT]);
 }
 
 sub masterStatus {
 	my $executor = shift;
-	return $executor->dbh()->selectrow_array("SHOW MASTER STATUS");
+	my $modern = _usesModernReplicationSyntax($executor->version());
+	return $executor->dbh()->selectrow_array($modern ? "SHOW BINARY LOG STATUS" : "SHOW MASTER STATUS");
 }
 
 #

--- a/randgen/lib/GenTest/Executor/MySQL.pm
+++ b/randgen/lib/GenTest/Executor/MySQL.pm
@@ -28,6 +28,7 @@ use GenTest::Constants;
 use GenTest::Result;
 use GenTest::Executor;
 use GenTest::QueryPerformance;
+use GenTest::ReplicationTerms;
 use Time::HiRes;
 use Digest::MD5;
 
@@ -803,37 +804,31 @@ sub version {
 	return $dbh->selectrow_array("SELECT VERSION()");
 }
 
-# MySQL/Percona 8.0.23 introduced REPLICA/SOURCE terminology as accepted
-# aliases for the original SLAVE/MASTER replication statements, then 8.4.0
-# removed the original statements outright -- SHOW SLAVE HOSTS and
-# SHOW MASTER STATUS are hard syntax errors from 8.4 onward, not just
-# deprecation warnings (confirmed live against a Percona Server 9.7 build).
-# MariaDB never made this change and only accepts the original statements at
-# every current version. Column layout is unchanged in both renames, only
-# the statement text differs.
-sub _usesModernReplicationSyntax {
-	my ($version_string) = @_;
-	return 0 if not defined $version_string;
-	return 0 if $version_string =~ m{mariadb}sio;
-	my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
-	return 0 if not defined $major;
-	return (($major > 8) ||
-	        ($major == 8 && $minor > 0) ||
-	        ($major == 8 && $minor == 0 && $patch >= 23)) ? 1 : 0;
+# Public wrappers around GenTest::ReplicationTerms so callers can ask the
+# executor (which already knows how to fetch VERSION()) without reaching into
+# a private helper. Results are cached by version string inside ReplicationTerms.
+sub usesModernReplicationSyntax {
+	my $executor = shift;
+	return GenTest::ReplicationTerms::usesModernReplicationSyntax($executor->version());
+}
+
+sub replicationTerms {
+	my $executor = shift;
+	return GenTest::ReplicationTerms::replicationTerms($executor->version());
 }
 
 sub slaveInfo {
 	my $executor = shift;
-	my $modern = _usesModernReplicationSyntax($executor->version());
-	my $slave_info = $executor->dbh()->selectrow_arrayref($modern ? "SHOW REPLICAS" : "SHOW SLAVE HOSTS");
+	my $terms = $executor->replicationTerms();
+	my $slave_info = $executor->dbh()->selectrow_arrayref($terms->{replicas});
 	return ('', '') if not defined $slave_info;
 	return ($slave_info->[SLAVE_INFO_HOST], $slave_info->[SLAVE_INFO_PORT]);
 }
 
 sub masterStatus {
 	my $executor = shift;
-	my $modern = _usesModernReplicationSyntax($executor->version());
-	return $executor->dbh()->selectrow_array($modern ? "SHOW BINARY LOG STATUS" : "SHOW MASTER STATUS");
+	my $terms = $executor->replicationTerms();
+	return $executor->dbh()->selectrow_array($terms->{binlog_status});
 }
 
 #

--- a/randgen/lib/GenTest/ReplicationTerms.pm
+++ b/randgen/lib/GenTest/ReplicationTerms.pm
@@ -51,6 +51,19 @@ my %LEGACY_REPLICATION_TERMS = (
 	pos_wait_func         => 'MASTER_POS_WAIT',
 	replica_status        => 'SHOW SLAVE STATUS',
 	replicas              => 'SHOW SLAVE HOSTS',
+	# Semi-sync plugin: system/status variable names, not just statement
+	# text. Confirmed live against Percona Server 9.7 -- the *_source_*/
+	# *_replica_* names below don't exist there at all; only *_master_*/
+	# *_slave_* do on a legacy-syntax server (installing the semisync_master/
+	# semisync_slave plugins registers these names).
+	semisync_source_enabled       => 'rpl_semi_sync_master_enabled',
+	semisync_source_trace_level   => 'rpl_semi_sync_master_trace_level',
+	semisync_source_timeout       => 'rpl_semi_sync_master_timeout',
+	semisync_replica_enabled      => 'rpl_semi_sync_slave_enabled',
+	semisync_replica_trace_level  => 'rpl_semi_sync_slave_trace_level',
+	semisync_source_status        => 'Rpl_semi_sync_master_status',
+	semisync_source_yes_tx        => 'Rpl_semi_sync_master_yes_tx',
+	semisync_source_no_tx         => 'Rpl_semi_sync_master_no_tx',
 );
 
 my %MODERN_REPLICATION_TERMS = (
@@ -69,9 +82,22 @@ my %MODERN_REPLICATION_TERMS = (
 	pos_wait_func         => 'SOURCE_POS_WAIT',
 	replica_status        => 'SHOW REPLICA STATUS',
 	replicas              => 'SHOW REPLICAS',
+	# Confirmed live against Percona Server 9.7: installing
+	# semisync_source.so/semisync_replica.so registers exactly these names
+	# (SHOW VARIABLES/SHOW STATUS LIKE '%semi_sync%'); the legacy
+	# rpl_semi_sync_master_*/rpl_semi_sync_slave_* names are not present.
+	semisync_source_enabled       => 'rpl_semi_sync_source_enabled',
+	semisync_source_trace_level   => 'rpl_semi_sync_source_trace_level',
+	semisync_source_timeout       => 'rpl_semi_sync_source_timeout',
+	semisync_replica_enabled      => 'rpl_semi_sync_replica_enabled',
+	semisync_replica_trace_level  => 'rpl_semi_sync_replica_trace_level',
+	semisync_source_status        => 'Rpl_semi_sync_source_status',
+	semisync_source_yes_tx        => 'Rpl_semi_sync_source_yes_tx',
+	semisync_source_no_tx         => 'Rpl_semi_sync_source_no_tx',
 );
 
 my %_modern_cache;
+my %_binlog_status_cache;
 
 sub usesModernReplicationSyntax {
 	my ($version_string) = @_;
@@ -93,11 +119,40 @@ sub usesModernReplicationSyntax {
 	return $modern;
 }
 
+# SHOW BINARY LOG STATUS (replacing SHOW MASTER STATUS) landed later than the
+# rest of the SOURCE/REPLICA rollout: confirmed live that Percona Server
+# 8.0.46 accepts SHOW REPLICA STATUS/SHOW REPLICAS/CHANGE REPLICATION SOURCE
+# TO/SOURCE_POS_WAIT() but rejects SHOW BINARY LOG STATUS as a syntax error,
+# while it works from MySQL 8.2.0 onward. Gate this term on its own boundary
+# rather than the 8.0.23 one used for everything else.
+sub usesBinaryLogStatusSyntax {
+	my ($version_string) = @_;
+	return 0 if not defined $version_string;
+	return $_binlog_status_cache{$version_string} if exists $_binlog_status_cache{$version_string};
+
+	my $modern = 0;
+	if ($version_string !~ m{mariadb}sio) {
+		my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
+		if (defined $major &&
+		    (($major > 8) ||
+		     ($major == 8 && $minor >= 2))) {
+			$modern = 1;
+		}
+	}
+
+	$_binlog_status_cache{$version_string} = $modern;
+	return $modern;
+}
+
 sub replicationTerms {
 	my ($version_string) = @_;
-	return usesModernReplicationSyntax($version_string)
-		? \%MODERN_REPLICATION_TERMS
-		: \%LEGACY_REPLICATION_TERMS;
+	my %terms = usesModernReplicationSyntax($version_string)
+		? %MODERN_REPLICATION_TERMS
+		: %LEGACY_REPLICATION_TERMS;
+
+	$terms{binlog_status} = 'SHOW MASTER STATUS' if not usesBinaryLogStatusSyntax($version_string);
+
+	return \%terms;
 }
 
 1;

--- a/randgen/lib/GenTest/ReplicationTerms.pm
+++ b/randgen/lib/GenTest/ReplicationTerms.pm
@@ -1,0 +1,103 @@
+# Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+# Use is subject to license terms.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+# USA
+
+package GenTest::ReplicationTerms;
+
+# MySQL/Percona 8.0.23 introduced SOURCE/REPLICA replication terminology as
+# accepted aliases for the original MASTER/SLAVE terms; 8.4.0 then removed the
+# original terms outright (STOP SLAVE / CHANGE MASTER TO / START SLAVE /
+# SHOW MASTER STATUS / SHOW SLAVE STATUS / MASTER_POS_WAIT() / SHOW SLAVE HOSTS
+# are hard syntax errors from 8.4 onward). MariaDB never made this change and
+# only accepts the original terminology. Picking the wrong vocabulary fails
+# replication setup/validation outright, so callers should obtain statements
+# from this module based on the server version string.
+
+use strict;
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(
+	usesModernReplicationSyntax
+	replicationTerms
+);
+
+my %LEGACY_REPLICATION_TERMS = (
+	stop_replica          => 'STOP SLAVE',
+	stop_replica_io       => 'STOP SLAVE IO_THREAD',
+	change_source         => 'CHANGE MASTER TO',
+	source_port           => 'MASTER_PORT',
+	source_host           => 'MASTER_HOST',
+	source_user           => 'MASTER_USER',
+	source_connect_retry  => 'MASTER_CONNECT_RETRY',
+	source_log_file       => 'MASTER_LOG_FILE',
+	source_log_pos        => 'MASTER_LOG_POS',
+	start_replica         => 'START SLAVE',
+	start_replica_io      => 'START SLAVE IO_THREAD',
+	binlog_status         => 'SHOW MASTER STATUS',
+	pos_wait_func         => 'MASTER_POS_WAIT',
+	replica_status        => 'SHOW SLAVE STATUS',
+	replicas              => 'SHOW SLAVE HOSTS',
+);
+
+my %MODERN_REPLICATION_TERMS = (
+	stop_replica          => 'STOP REPLICA',
+	stop_replica_io       => 'STOP REPLICA IO_THREAD',
+	change_source         => 'CHANGE REPLICATION SOURCE TO',
+	source_port           => 'SOURCE_PORT',
+	source_host           => 'SOURCE_HOST',
+	source_user           => 'SOURCE_USER',
+	source_connect_retry  => 'SOURCE_CONNECT_RETRY',
+	source_log_file       => 'SOURCE_LOG_FILE',
+	source_log_pos        => 'SOURCE_LOG_POS',
+	start_replica         => 'START REPLICA',
+	start_replica_io      => 'START REPLICA IO_THREAD',
+	binlog_status         => 'SHOW BINARY LOG STATUS',
+	pos_wait_func         => 'SOURCE_POS_WAIT',
+	replica_status        => 'SHOW REPLICA STATUS',
+	replicas              => 'SHOW REPLICAS',
+);
+
+my %_modern_cache;
+
+sub usesModernReplicationSyntax {
+	my ($version_string) = @_;
+	return 0 if not defined $version_string;
+	return $_modern_cache{$version_string} if exists $_modern_cache{$version_string};
+
+	my $modern = 0;
+	if ($version_string !~ m{mariadb}sio) {
+		my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
+		if (defined $major &&
+		    (($major > 8) ||
+		     ($major == 8 && $minor > 0) ||
+		     ($major == 8 && $minor == 0 && $patch >= 23))) {
+			$modern = 1;
+		}
+	}
+
+	$_modern_cache{$version_string} = $modern;
+	return $modern;
+}
+
+sub replicationTerms {
+	my ($version_string) = @_;
+	return usesModernReplicationSyntax($version_string)
+		? \%MODERN_REPLICATION_TERMS
+		: \%LEGACY_REPLICATION_TERMS;
+}
+
+1;

--- a/randgen/lib/GenTest/ReplicationTerms.pm
+++ b/randgen/lib/GenTest/ReplicationTerms.pm
@@ -51,6 +51,11 @@ my %LEGACY_REPLICATION_TERMS = (
 	pos_wait_func         => 'MASTER_POS_WAIT',
 	replica_status        => 'SHOW SLAVE STATUS',
 	replicas              => 'SHOW SLAVE HOSTS',
+	# Bare noun for callers that build START/STOP <noun> <arbitrary thread
+	# clause> themselves rather than using the start_replica*/stop_replica*
+	# statements above (which only cover the "both threads" and "IO_THREAD
+	# only" cases).
+	replica_keyword       => 'SLAVE',
 	# Semi-sync plugin: system/status variable names, not just statement
 	# text. Confirmed live against Percona Server 9.7 -- the *_source_*/
 	# *_replica_* names below don't exist there at all; only *_master_*/
@@ -82,6 +87,7 @@ my %MODERN_REPLICATION_TERMS = (
 	pos_wait_func         => 'SOURCE_POS_WAIT',
 	replica_status        => 'SHOW REPLICA STATUS',
 	replicas              => 'SHOW REPLICAS',
+	replica_keyword       => 'REPLICA',
 	# Confirmed live against Percona Server 9.7: installing
 	# semisync_source.so/semisync_replica.so registers exactly these names
 	# (SHOW VARIABLES/SHOW STATUS LIKE '%semi_sync%'); the legacy
@@ -98,6 +104,7 @@ my %MODERN_REPLICATION_TERMS = (
 
 my %_modern_cache;
 my %_binlog_status_cache;
+my %_pos_wait_cache;
 
 sub usesModernReplicationSyntax {
 	my ($version_string) = @_;
@@ -144,6 +151,32 @@ sub usesBinaryLogStatusSyntax {
 	return $modern;
 }
 
+# SOURCE_POS_WAIT() also landed later than the rest of the SOURCE/REPLICA
+# rollout: confirmed live against Percona Server 8.0.23-14 and 8.0.25-15 that
+# SOURCE_POS_WAIT() is rejected with "FUNCTION ... does not exist" (it isn't
+# a registered builtin yet) even though SHOW REPLICA STATUS/SHOW REPLICAS/
+# CHANGE REPLICATION SOURCE TO/START REPLICA/STOP REPLICA all already work,
+# and MASTER_POS_WAIT() still does. Gate this term on its own boundary too.
+sub usesSourcePosWaitSyntax {
+	my ($version_string) = @_;
+	return 0 if not defined $version_string;
+	return $_pos_wait_cache{$version_string} if exists $_pos_wait_cache{$version_string};
+
+	my $modern = 0;
+	if ($version_string !~ m{mariadb}sio) {
+		my ($major, $minor, $patch) = $version_string =~ m{^(\d+)\.(\d+)\.(\d+)}sio;
+		if (defined $major &&
+		    (($major > 8) ||
+		     ($major == 8 && $minor > 0) ||
+		     ($major == 8 && $minor == 0 && $patch >= 26))) {
+			$modern = 1;
+		}
+	}
+
+	$_pos_wait_cache{$version_string} = $modern;
+	return $modern;
+}
+
 sub replicationTerms {
 	my ($version_string) = @_;
 	my %terms = usesModernReplicationSyntax($version_string)
@@ -151,6 +184,7 @@ sub replicationTerms {
 		: %LEGACY_REPLICATION_TERMS;
 
 	$terms{binlog_status} = 'SHOW MASTER STATUS' if not usesBinaryLogStatusSyntax($version_string);
+	$terms{pos_wait_func} = 'MASTER_POS_WAIT' if not usesSourcePosWaitSyntax($version_string);
 
 	return \%terms;
 }

--- a/randgen/lib/GenTest/Reporter.pm
+++ b/randgen/lib/GenTest/Reporter.pm
@@ -34,6 +34,7 @@ use strict;
 use GenTest;
 use GenTest::Result;
 use GenTest::Random;
+use GenTest::ReplicationTerms qw(replicationTerms);
 use DBI;
 use File::Find;
 use File::Spec;
@@ -87,9 +88,11 @@ sub new {
 
 	$sth->finish();
 
-	# SHOW SLAVE HOSTS may fail if user does not have the REPLICATION SLAVE privilege
+	# SHOW SLAVE HOSTS / SHOW REPLICAS may fail if user does not have the
+	# REPLICATION SLAVE privilege
 	$dbh->{PrintError} = 0;
-	my $slave_info = $dbh->selectrow_arrayref("SHOW SLAVE HOSTS");
+	my $terms = replicationTerms($reporter->serverVariable('version'));
+	my $slave_info = $dbh->selectrow_arrayref($terms->{replicas});
 	$dbh->{PrintError} = 1;
 	if (defined $slave_info) {
 		$reporter->[REPORTER_SERVER_INFO]->{slave_host} = $slave_info->[1];

--- a/randgen/lib/GenTest/Reporter.pm
+++ b/randgen/lib/GenTest/Reporter.pm
@@ -92,11 +92,11 @@ sub new {
 	# REPLICATION SLAVE privilege
 	$dbh->{PrintError} = 0;
 	my $terms = replicationTerms($reporter->serverVariable('version'));
-	my $slave_info = $dbh->selectrow_arrayref($terms->{replicas});
+	my $replica_info = $dbh->selectrow_arrayref($terms->{replicas});
 	$dbh->{PrintError} = 1;
-	if (defined $slave_info) {
-		$reporter->[REPORTER_SERVER_INFO]->{slave_host} = $slave_info->[1];
-		$reporter->[REPORTER_SERVER_INFO]->{slave_port} = $slave_info->[2];
+	if (defined $replica_info) {
+		$reporter->[REPORTER_SERVER_INFO]->{replica_host} = $replica_info->[1];
+		$reporter->[REPORTER_SERVER_INFO]->{replica_port} = $replica_info->[2];
 	}
 
 	if ($reporter->serverVariable('version') !~ m{^5\.0}sgio) {

--- a/randgen/lib/GenTest/Reporter/CloneSlave.pm
+++ b/randgen/lib/GenTest/Reporter/CloneSlave.pm
@@ -49,7 +49,7 @@ sub monitor {
 	my $reporter = shift;
 
 	# In case of two servers, we will be called twice.
-	# Only clone a slave when called for the master
+	# Only clone a replica when called for the source
 
         $first_reporter = $reporter if not defined $first_reporter;
         return STATUS_OK if $reporter ne $first_reporter;
@@ -78,16 +78,16 @@ sub monitor {
 	my $lc_messages_dir = $reporter->serverVariable('lc_messages_dir');
 	my $datadir = $reporter->serverVariable('datadir');
 	$datadir =~ s{[\\/]$}{}sgio;
-	my $slave_datadir = $datadir.'_clonedslave';
-	mkdir($slave_datadir);
-	my $master_port = $reporter->serverVariable('port');
-	my $slave_port = $master_port + 4;
+	my $replica_datadir = $datadir.'_clonedslave';
+	mkdir($replica_datadir);
+	my $source_port = $reporter->serverVariable('port');
+	my $replica_port = $source_port + 4;
 	my $pid = $reporter->serverInfo('pid');
 	my $plugin_dir = $reporter->serverVariable('plugin_dir');
 	my $plugins = $reporter->serverPlugins();
 	my $engine = $reporter->serverVariable('storage_engine');
 
-	my $master_dbh = DBI->connect($reporter->dsn());
+	my $source_dbh = DBI->connect($reporter->dsn());
 
 	my @mysqld_options = (
 		'--no-defaults',
@@ -96,15 +96,15 @@ sub monitor {
 		'--loose-console',
 		'--language='.$language,
 		'--loose-lc-messages-dir='.$lc_messages_dir,
-		'--datadir="'.$slave_datadir.'"',
+		'--datadir="'.$replica_datadir.'"',
 		'--log-output=file',
 		'--skip-grant-tables',
 		'--general-log',
 		'--relay-log=clonedslave-relay',
-		'--general_log_file="'.$slave_datadir.'/clonedslave.log"',
-		'--log_error="'.$slave_datadir.'/clonedslave.err"',
-		'--datadir="'.$slave_datadir.'"',
-		'--port='.$slave_port,
+		'--general_log_file="'.$replica_datadir.'/clonedslave.log"',
+		'--log_error="'.$replica_datadir.'/clonedslave.err"',
+		'--datadir="'.$replica_datadir.'"',
+		'--port='.$replica_port,
 		'--loose-plugin-dir='.$plugin_dir,
 		'--max-allowed-packet=20M',
 		'--innodb',
@@ -116,53 +116,53 @@ sub monitor {
 	};
 
 	my $mysqld_command = $binary.' '.join(' ', @mysqld_options).' 2>&1';
-	say("Starting a new mysqld for the cloned slave.");
+	say("Starting a new mysqld for the cloned replica.");
 	say("$mysqld_command.");
 	my $mysqld_pid = open2(\*RDRFH, \*WTRFH, $mysqld_command);
 
-	my $slave_dbh;
+	my $replica_dbh;
 
 	foreach my $try (1..120) {
 		sleep(1);
-		$slave_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$slave_port, undef, undef, { RaiseError => 0 , PrintError => 0 } );
-		next if not defined $slave_dbh;
-		last if $slave_dbh->ping();
+		$replica_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$replica_port, undef, undef, { RaiseError => 0 , PrintError => 0 } );
+		next if not defined $replica_dbh;
+		last if $replica_dbh->ping();
 	}
 
-	return STATUS_ENVIRONMENT_FAILURE if not defined $slave_dbh;
+	return STATUS_ENVIRONMENT_FAILURE if not defined $replica_dbh;
 
-	say("Cloned slave has started.");
-	
-        my @all_databases = @{$master_dbh->selectcol_arrayref("SHOW DATABASES")};
+	say("Cloned replica has started.");
+
+        my @all_databases = @{$source_dbh->selectcol_arrayref("SHOW DATABASES")};
         my $databases_string = join(' ', grep { $_ !~ m{^(mysql|information_schema|performance_schema)$}sgio } @all_databases );
 
-	my $dump_file = $slave_datadir.'/'.time().'.dump';
-	say("Dumping master to $dump_file ...");
-	my $mysqldump_command = "$client_basedir/mysqldump --max_allowed_packet=25M --net_buffer_length=1M -uroot --password='' --protocol=tcp --port=$master_port --single-transaction --master-data --skip-tz-utc --databases $databases_string > $dump_file";
+	my $dump_file = $replica_datadir.'/'.time().'.dump';
+	say("Dumping source to $dump_file ...");
+	my $mysqldump_command = "$client_basedir/mysqldump --max_allowed_packet=25M --net_buffer_length=1M -uroot --password='' --protocol=tcp --port=$source_port --single-transaction --master-data --skip-tz-utc --databases $databases_string > $dump_file";
 	say($mysqldump_command);
 	system($mysqldump_command);
 	return STATUS_ENVIRONMENT_FAILURE if $? != 0;
 	say("Mysqldump done.");
 
-	say("Loading dump from $dump_file into cloned slave ...");
-	my $mysql_command = "$client_basedir/mysql -uroot --password='' --max_allowed_packet=30M --protocol=tcp --port=$slave_port < $dump_file";
+	say("Loading dump from $dump_file into cloned replica ...");
+	my $mysql_command = "$client_basedir/mysql -uroot --password='' --max_allowed_packet=30M --protocol=tcp --port=$replica_port < $dump_file";
 	say($mysql_command);
 	system($mysql_command);
 	return STATUS_ENVIRONMENT_FAILURE if $? != 0;
 	say("Mysql done.");
 
-	say("Issuing START SLAVE / START REPLICA on the cloned slave.");
+	say("Issuing START SLAVE / START REPLICA on the cloned replica.");
 
 	my $terms = replicationTerms($reporter->serverVariable('version'));
-	$slave_dbh->do("
+	$replica_dbh->do("
 		".$terms->{change_source}."
-		".$terms->{source_port}." = ".$master_port.",
+		".$terms->{source_port}." = ".$source_port.",
 		".$terms->{source_host}." = '127.0.0.1',
 		".$terms->{source_user}." = 'root',
 		".$terms->{source_connect_retry}." = 1
 	");
 
-	$slave_dbh->do($terms->{start_replica});
+	$replica_dbh->do($terms->{start_replica});
 
 	return STATUS_OK;
 }
@@ -181,14 +181,14 @@ sub report {
 
 	die "can't determine client_basedir; basedir = $basedir" if not defined $client_basedir;
 
-	my $master_port = $reporter->serverVariable('port');
-	my $slave_port = $master_port + 4;
-	my $master_dbh = DBI->connect($reporter->dsn());
-	my $slave_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$slave_port, undef, undef, { RaiseError => 1 } );
+	my $source_port = $reporter->serverVariable('port');
+	my $replica_port = $source_port + 4;
+	my $source_dbh = DBI->connect($reporter->dsn());
+	my $replica_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$replica_port, undef, undef, { RaiseError => 1 } );
 	my $terms = replicationTerms($reporter->serverVariable('version'));
 
-	say("Issuing ".$terms->{start_replica}." on the cloned slave.");
-	$slave_dbh->do($terms->{start_replica});
+	say("Issuing ".$terms->{start_replica}." on the cloned replica.");
+	$replica_dbh->do($terms->{start_replica});
 
         #
         # We call MASTER_POS_WAIT / SOURCE_POS_WAIT at 100K increments in order
@@ -196,16 +196,16 @@ sub report {
         # 20 minutes.
         #
 
-        my $sth_binlogs = $master_dbh->prepare("SHOW BINARY LOGS");
+        my $sth_binlogs = $source_dbh->prepare("SHOW BINARY LOGS");
         $sth_binlogs->execute();
         while (my ($intermediate_binlog_file, $intermediate_binlog_size) = $sth_binlogs->fetchrow_array()) {
                 my $intermediate_binlog_pos = $intermediate_binlog_size < 10000000 ? $intermediate_binlog_size : 10000000;
                 do {
-                        say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned slave.");
-                        my $intermediate_wait_result = $slave_dbh->selectrow_array(
+                        say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned replica.");
+                        my $intermediate_wait_result = $replica_dbh->selectrow_array(
 				"SELECT ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos)");
                         if (not defined $intermediate_wait_result) {
-                                say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned slave on port $slave_port.");
+                                say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned replica on port $replica_port.");
                                 return STATUS_REPLICATION_FAILURE;
                         }
                         $intermediate_binlog_pos += 10000000;
@@ -213,23 +213,23 @@ sub report {
         }
 
 
-	my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
+	my ($final_binlog_file, $final_binlog_pos) = $source_dbh->selectrow_array($terms->{binlog_status});
 	exit_test(STATUS_UNKNOWN_ERROR) if !defined $final_binlog_file;
 
-        say("Waiting for cloned slave to catch up..., file $final_binlog_file, pos $final_binlog_pos .");
-	my $final_wait_result = $slave_dbh->selectrow_array(
+        say("Waiting for cloned replica to catch up..., file $final_binlog_file, pos $final_binlog_pos .");
+	my $final_wait_result = $replica_dbh->selectrow_array(
 		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos)");
 
 	if (not defined $final_wait_result) {
-                say($terms->{pos_wait_func}."() failed. Cloned slave replication thread not running.");
+                say($terms->{pos_wait_func}."() failed. Cloned replica replication thread not running.");
                 return STATUS_REPLICATION_FAILURE;        }
-	
-	say("Cloned slave caught up.");
 
-        my @all_databases = @{$master_dbh->selectcol_arrayref("SHOW DATABASES")};
+	say("Cloned replica caught up.");
+
+        my @all_databases = @{$source_dbh->selectcol_arrayref("SHOW DATABASES")};
         my $databases_string = join(' ', grep { $_ !~ m{^(mysql|information_schema|performance_schema)$}sgio } @all_databases );
-		
-	my @dump_ports = ($master_port, $slave_port);
+
+	my @dump_ports = ($source_port, $replica_port);
 	my @dump_files;
 
 	foreach my $i (0..$#dump_ports) {
@@ -244,7 +244,7 @@ sub report {
 	my $diff_result = system("diff -u $dump_files[0] $dump_files[1]") >> 8;
 
 	if ($diff_result == 0) {
-		say("No differences were found between master and cloned slave.");
+		say("No differences were found between source and cloned replica.");
         }
 
         foreach my $dump_file (@dump_files) {

--- a/randgen/lib/GenTest/Reporter/CloneSlave.pm
+++ b/randgen/lib/GenTest/Reporter/CloneSlave.pm
@@ -27,6 +27,7 @@ use GenTest;
 use GenTest::Constants;
 use GenTest::Reporter;
 use GenTest::Comparator;
+use GenTest::ReplicationTerms qw(replicationTerms);
 use Data::Dumper;
 use IPC::Open2;
 use IPC::Open3;
@@ -137,30 +138,31 @@ sub monitor {
 
 	my $dump_file = $slave_datadir.'/'.time().'.dump';
 	say("Dumping master to $dump_file ...");
-	my $mysqldump_command = $client_basedir.'/mysqldump --max_allowed_packet=25M --net_buffer_length=1M -uroot --password='' --protocol=tcp --port='.$master_port.' --single-transaction --master-data --skip-tz-utc --databases '.$databases_string.' > '.$dump_file;
+	my $mysqldump_command = "$client_basedir/mysqldump --max_allowed_packet=25M --net_buffer_length=1M -uroot --password='' --protocol=tcp --port=$master_port --single-transaction --master-data --skip-tz-utc --databases $databases_string > $dump_file";
 	say($mysqldump_command);
 	system($mysqldump_command);
 	return STATUS_ENVIRONMENT_FAILURE if $? != 0;
 	say("Mysqldump done.");
 
 	say("Loading dump from $dump_file into cloned slave ...");
-	my $mysql_command = $client_basedir.'/mysql -uroot --password='' --max_allowed_packet=30M --protocol=tcp --port='.$slave_port.' < '.$dump_file;
+	my $mysql_command = "$client_basedir/mysql -uroot --password='' --max_allowed_packet=30M --protocol=tcp --port=$slave_port < $dump_file";
 	say($mysql_command);
 	system($mysql_command);
 	return STATUS_ENVIRONMENT_FAILURE if $? != 0;
 	say("Mysql done.");
 
-	say("Issuing START SLAVE on the cloned slave.");
+	say("Issuing START SLAVE / START REPLICA on the cloned slave.");
 
+	my $terms = replicationTerms($reporter->serverVariable('version'));
 	$slave_dbh->do("
-		CHANGE MASTER TO
-		MASTER_PORT = ".$master_port.",
-		MASTER_HOST = '127.0.0.1',
-		MASTER_USER = 'root',
-		MASTER_CONNECT_RETRY = 1
+		".$terms->{change_source}."
+		".$terms->{source_port}." = ".$master_port.",
+		".$terms->{source_host}." = '127.0.0.1',
+		".$terms->{source_user}." = 'root',
+		".$terms->{source_connect_retry}." = 1
 	");
 
-	$slave_dbh->do("START SLAVE");
+	$slave_dbh->do($terms->{start_replica});
 
 	return STATUS_OK;
 }
@@ -183,13 +185,15 @@ sub report {
 	my $slave_port = $master_port + 4;
 	my $master_dbh = DBI->connect($reporter->dsn());
 	my $slave_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$slave_port, undef, undef, { RaiseError => 1 } );
+	my $terms = replicationTerms($reporter->serverVariable('version'));
 
-	say("Issuing START SLAVE on the cloned slave.");
-	$slave_dbh->do("START SLAVE");
+	say("Issuing ".$terms->{start_replica}." on the cloned slave.");
+	$slave_dbh->do($terms->{start_replica});
 
         #
-        # We call MASTER_POS_WAIT at 100K increments in order to avoid buildbot timeout in case
-        # one big MASTER_POS_WAIT would take more than 20 minutes.
+        # We call MASTER_POS_WAIT / SOURCE_POS_WAIT at 100K increments in order
+        # to avoid buildbot timeout in case one big wait would take more than
+        # 20 minutes.
         #
 
         my $sth_binlogs = $master_dbh->prepare("SHOW BINARY LOGS");
@@ -197,10 +201,11 @@ sub report {
         while (my ($intermediate_binlog_file, $intermediate_binlog_size) = $sth_binlogs->fetchrow_array()) {
                 my $intermediate_binlog_pos = $intermediate_binlog_size < 10000000 ? $intermediate_binlog_size : 10000000;
                 do {
-                        say("Executing intermediate MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned slave.");
-                        my $intermediate_wait_result = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos)");
+                        say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned slave.");
+                        my $intermediate_wait_result = $slave_dbh->selectrow_array(
+				"SELECT ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos)");
                         if (not defined $intermediate_wait_result) {
-                                say("Intermediate MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned slave on port $slave_port.");
+                                say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned slave on port $slave_port.");
                                 return STATUS_REPLICATION_FAILURE;
                         }
                         $intermediate_binlog_pos += 10000000;
@@ -208,14 +213,15 @@ sub report {
         }
 
 
-	my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array("SHOW MASTER STATUS");
+	my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
 	exit_test(STATUS_UNKNOWN_ERROR) if !defined $final_binlog_file;
 
         say("Waiting for cloned slave to catch up..., file $final_binlog_file, pos $final_binlog_pos .");
-	my $final_wait_result = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT('$final_binlog_file', $final_binlog_pos)");
+	my $final_wait_result = $slave_dbh->selectrow_array(
+		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos)");
 
 	if (not defined $final_wait_result) {
-                say("MASTER_POS_WAIT() failed. Cloned slave replication thread not running.");
+                say($terms->{pos_wait_func}."() failed. Cloned slave replication thread not running.");
                 return STATUS_REPLICATION_FAILURE;        }
 	
 	say("Cloned slave caught up.");

--- a/randgen/lib/GenTest/Reporter/CloneSlaveXtrabackup.pm
+++ b/randgen/lib/GenTest/Reporter/CloneSlaveXtrabackup.pm
@@ -27,6 +27,7 @@ use GenTest;
 use GenTest::Constants;
 use GenTest::Reporter;
 use GenTest::Comparator;
+use GenTest::ReplicationTerms qw(replicationTerms);
 use Data::Dumper;
 use IPC::Open2;
 use IPC::Open3;
@@ -164,21 +165,22 @@ sub monitor {
 
 	say("Cloned slave has started.");
 	
-	say("Issuing START SLAVE on the cloned slave...");
+	say("Issuing START SLAVE / START REPLICA on the cloned slave...");
 
+	my $terms = replicationTerms($reporter->serverVariable('version'));
 	$slave_dbh->do("
-		CHANGE MASTER TO
-		MASTER_PORT = ".$master_port.",
-		MASTER_HOST = '127.0.0.1',
-		MASTER_LOG_FILE = '$binlog_file',
-		MASTER_LOG_POS = $binlog_pos,
-		MASTER_USER = 'root',
-		MASTER_CONNECT_RETRY = 1
+		".$terms->{change_source}."
+		".$terms->{source_port}." = ".$master_port.",
+		".$terms->{source_host}." = '127.0.0.1',
+		".$terms->{source_log_file}." = '$binlog_file',
+		".$terms->{source_log_pos}." = $binlog_pos,
+		".$terms->{source_user}." = 'root',
+		".$terms->{source_connect_retry}." = 1
 	");
 
-	$slave_dbh->do("START SLAVE");
+	$slave_dbh->do($terms->{start_replica});
 
-	say("START SLAVE was issued. The main test/workload will now continue.");
+	say($terms->{start_replica}." was issued. The main test/workload will now continue.");
 
 	return STATUS_OK;
 }
@@ -201,18 +203,20 @@ sub report {
 	my $slave_port = $master_port + 4;
 	my $master_dbh = DBI->connect($reporter->dsn());
 	my $slave_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$slave_port, undef, undef, { RaiseError => 1 } );
+	my $terms = replicationTerms($reporter->serverVariable('version'));
 
-	say("Issuing START SLAVE on the cloned slave.");
-	$slave_dbh->do("START SLAVE");
+	say("Issuing ".$terms->{start_replica}." on the cloned slave.");
+	$slave_dbh->do($terms->{start_replica});
 
-	my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array("SHOW MASTER STATUS");
+	my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
 	exit_test(STATUS_UNKNOWN_ERROR) if !defined $final_binlog_file;
 
 	say("The cloned slave must catch up to $final_binlog_file:$final_binlog_pos.");
 
         #
-        # We call MASTER_POS_WAIT at 100K increments in order to avoid buildbot timeout in case
-        # one big MASTER_POS_WAIT would take more than 20 minutes.
+        # We call MASTER_POS_WAIT / SOURCE_POS_WAIT at 100K increments in order
+        # to avoid buildbot timeout in case one big wait would take more than
+        # 20 minutes.
         #
 
         my $sth_binlogs = $master_dbh->prepare("SHOW BINARY LOGS");
@@ -220,10 +224,11 @@ sub report {
         while (my ($intermediate_binlog_file, $intermediate_binlog_size) = $sth_binlogs->fetchrow_array()) {
                 my $intermediate_binlog_pos = $intermediate_binlog_size < 10000000 ? $intermediate_binlog_size : 10000000;
                 do {
-                        say("Executing intermediate MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned slave.");
-                        my $intermediate_wait_result = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos)");
+                        say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned slave.");
+                        my $intermediate_wait_result = $slave_dbh->selectrow_array(
+				"SELECT ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos)");
                         if (not defined $intermediate_wait_result) {
-                                say("Intermediate MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned slave on port $slave_port.");
+                                say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned slave on port $slave_port.");
                                 return STATUS_REPLICATION_FAILURE;
                         }
                         $intermediate_binlog_pos += 10000000;
@@ -231,10 +236,11 @@ sub report {
         }
 
         say("Waiting for cloned slave to catch up..., file $final_binlog_file, pos $final_binlog_pos .");
-	my $final_wait_result = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT('$final_binlog_file', $final_binlog_pos)");
+	my $final_wait_result = $slave_dbh->selectrow_array(
+		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos)");
 
 	if (not defined $final_wait_result) {
-                say("MASTER_POS_WAIT() failed. Cloned slave replication thread not running.");
+                say($terms->{pos_wait_func}."() failed. Cloned slave replication thread not running.");
                 return STATUS_REPLICATION_FAILURE;        }
 	
 	say("Cloned slave caught up.");

--- a/randgen/lib/GenTest/Reporter/CloneSlaveXtrabackup.pm
+++ b/randgen/lib/GenTest/Reporter/CloneSlaveXtrabackup.pm
@@ -49,7 +49,7 @@ sub monitor {
 	my $reporter = shift;
 
 	# In case of two servers, we will be called twice.
-	# Only clone a slave when called for the master
+	# Only clone a replica when called for the source
 
         $first_reporter = $reporter if not defined $first_reporter;
         return STATUS_OK if $reporter ne $first_reporter;
@@ -75,21 +75,21 @@ sub monitor {
 	my $lc_messages_dir = $reporter->serverVariable('lc_messages_dir');
 	my $datadir = $reporter->serverVariable('datadir');
 	$datadir =~ s{[\\/]$}{}sgio;
-	my $slave_datadir = $datadir.'_clonedslave_xtrabackup';
-	mkdir($slave_datadir);
-	my $master_port = $reporter->serverVariable('port');
-	my $slave_port = $master_port + 4;
+	my $replica_datadir = $datadir.'_clonedslave_xtrabackup';
+	mkdir($replica_datadir);
+	my $source_port = $reporter->serverVariable('port');
+	my $replica_port = $source_port + 4;
 	my $plugin_dir = $reporter->serverVariable('plugin_dir');
 	my $plugins = $reporter->serverPlugins();
 
-	my $master_dbh = DBI->connect($reporter->dsn());
+	my $source_dbh = DBI->connect($reporter->dsn());
 
-	my $xtrabackup_backup_command = "xtrabackup --backup --datadir=$datadir --target-dir=$slave_datadir";
+	my $xtrabackup_backup_command = "xtrabackup --backup --datadir=$datadir --target-dir=$replica_datadir";
 	say("Executing backup: $xtrabackup_backup_command");
 	system($xtrabackup_backup_command);
 	return STATUS_ENVIRONMENT_FAILURE if $! != 0;
 
-	my $xtrabackup_prepare_command = "xtrabackup --prepare --target-dir=$slave_datadir";
+	my $xtrabackup_prepare_command = "xtrabackup --prepare --target-dir=$replica_datadir";
 	say("Executing first prepare: $xtrabackup_prepare_command");
 	system($xtrabackup_prepare_command);
 	return STATUS_ENVIRONMENT_FAILURE if $! != 0;
@@ -98,7 +98,7 @@ sub monitor {
 	system($xtrabackup_prepare_command);
 	return STATUS_ENVIRONMENT_FAILURE if $! != 0;
 
-	my $binlog_pos_file = $slave_datadir.'/xtrabackup_binlog_pos_innodb';
+	my $binlog_pos_file = $replica_datadir.'/xtrabackup_binlog_pos_innodb';
 	open(BINLOG_POS_FILE, $binlog_pos_file);
 	read(BINLOG_POS_FILE, my $binlog_pos_text, -s $binlog_pos_file);
 	chomp($binlog_pos_text);
@@ -111,13 +111,13 @@ sub monitor {
 		say("Xtrabackup reports: master_log_file: $binlog_file; master_log_pos: $binlog_pos.");
 	}
 
-        system("cp -r $datadir/mysql $slave_datadir/");
+        system("cp -r $datadir/mysql $replica_datadir/");
 
-        my @all_databases = @{$master_dbh->selectcol_arrayref("SHOW DATABASES")};
+        my @all_databases = @{$source_dbh->selectcol_arrayref("SHOW DATABASES")};
 	foreach my $database (grep { $_ !~ m{^(information_schema|performance_schema)$}sgio } @all_databases ) {
 		system("Copying .frm files for database $database...");
-		mkdir("$slave_datadir/$database");
-	        system("cp -r $datadir/$database/*.frm $slave_datadir/$database");
+		mkdir("$replica_datadir/$database");
+	        system("cp -r $datadir/$database/*.frm $replica_datadir/$database");
 	}
 
 	my @mysqld_options = (
@@ -127,15 +127,15 @@ sub monitor {
 		'--loose-console',
 		'--language='.$language,
 		'--loose-lc-messages-dir='.$lc_messages_dir,
-		'--datadir="'.$slave_datadir.'"',
+		'--datadir="'.$replica_datadir.'"',
 		'--log-output=file',
 		'--skip-grant-tables',
 		'--general-log',
 		'--relay-log=clonedslave-relay',
-		'--general_log_file="'.$slave_datadir.'/clonedslave.log"',
-		'--log_error="'.$slave_datadir.'/clonedslave.err"',
-		'--datadir="'.$slave_datadir.'"',
-		'--port='.$slave_port,
+		'--general_log_file="'.$replica_datadir.'/clonedslave.log"',
+		'--log_error="'.$replica_datadir.'/clonedslave.err"',
+		'--datadir="'.$replica_datadir.'"',
+		'--port='.$replica_port,
 		'--loose-plugin-dir='.$plugin_dir,
 		'--max-allowed-packet=20M',
 		'--innodb',
@@ -148,29 +148,29 @@ sub monitor {
 	};
 
 	my $mysqld_command = $binary.' '.join(' ', @mysqld_options).' 2>&1';
-	say("Starting a new mysqld for the cloned slave.");
+	say("Starting a new mysqld for the cloned replica.");
 	say("$mysqld_command.");
 	my $mysqld_pid = open2(\*RDRFH, \*WTRFH, $mysqld_command);
 
-	my $slave_dbh;
+	my $replica_dbh;
 
 	foreach my $try (1..120) {
 		sleep(1);
-		$slave_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$slave_port, undef, undef, { RaiseError => 0 , PrintError => 0 } );
-		next if not defined $slave_dbh;
-		last if $slave_dbh->ping();
+		$replica_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$replica_port, undef, undef, { RaiseError => 0 , PrintError => 0 } );
+		next if not defined $replica_dbh;
+		last if $replica_dbh->ping();
 	}
 
-	return STATUS_ENVIRONMENT_FAILURE if not defined $slave_dbh;
+	return STATUS_ENVIRONMENT_FAILURE if not defined $replica_dbh;
 
-	say("Cloned slave has started.");
-	
-	say("Issuing START SLAVE / START REPLICA on the cloned slave...");
+	say("Cloned replica has started.");
+
+	say("Issuing START SLAVE / START REPLICA on the cloned replica...");
 
 	my $terms = replicationTerms($reporter->serverVariable('version'));
-	$slave_dbh->do("
+	$replica_dbh->do("
 		".$terms->{change_source}."
-		".$terms->{source_port}." = ".$master_port.",
+		".$terms->{source_port}." = ".$source_port.",
 		".$terms->{source_host}." = '127.0.0.1',
 		".$terms->{source_log_file}." = '$binlog_file',
 		".$terms->{source_log_pos}." = $binlog_pos,
@@ -178,7 +178,7 @@ sub monitor {
 		".$terms->{source_connect_retry}." = 1
 	");
 
-	$slave_dbh->do($terms->{start_replica});
+	$replica_dbh->do($terms->{start_replica});
 
 	say($terms->{start_replica}." was issued. The main test/workload will now continue.");
 
@@ -199,19 +199,19 @@ sub report {
 
 	die "can't determine client_basedir; basedir = $basedir" if not defined $client_basedir;
 
-	my $master_port = $reporter->serverVariable('port');
-	my $slave_port = $master_port + 4;
-	my $master_dbh = DBI->connect($reporter->dsn());
-	my $slave_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$slave_port, undef, undef, { RaiseError => 1 } );
+	my $source_port = $reporter->serverVariable('port');
+	my $replica_port = $source_port + 4;
+	my $source_dbh = DBI->connect($reporter->dsn());
+	my $replica_dbh = DBI->connect("dbi:mysql:user=root:host=127.0.0.1:port=".$replica_port, undef, undef, { RaiseError => 1 } );
 	my $terms = replicationTerms($reporter->serverVariable('version'));
 
-	say("Issuing ".$terms->{start_replica}." on the cloned slave.");
-	$slave_dbh->do($terms->{start_replica});
+	say("Issuing ".$terms->{start_replica}." on the cloned replica.");
+	$replica_dbh->do($terms->{start_replica});
 
-	my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
+	my ($final_binlog_file, $final_binlog_pos) = $source_dbh->selectrow_array($terms->{binlog_status});
 	exit_test(STATUS_UNKNOWN_ERROR) if !defined $final_binlog_file;
 
-	say("The cloned slave must catch up to $final_binlog_file:$final_binlog_pos.");
+	say("The cloned replica must catch up to $final_binlog_file:$final_binlog_pos.");
 
         #
         # We call MASTER_POS_WAIT / SOURCE_POS_WAIT at 100K increments in order
@@ -219,36 +219,36 @@ sub report {
         # 20 minutes.
         #
 
-        my $sth_binlogs = $master_dbh->prepare("SHOW BINARY LOGS");
+        my $sth_binlogs = $source_dbh->prepare("SHOW BINARY LOGS");
         $sth_binlogs->execute();
         while (my ($intermediate_binlog_file, $intermediate_binlog_size) = $sth_binlogs->fetchrow_array()) {
                 my $intermediate_binlog_pos = $intermediate_binlog_size < 10000000 ? $intermediate_binlog_size : 10000000;
                 do {
-                        say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned slave.");
-                        my $intermediate_wait_result = $slave_dbh->selectrow_array(
+                        say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) on cloned replica.");
+                        my $intermediate_wait_result = $replica_dbh->selectrow_array(
 				"SELECT ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos)");
                         if (not defined $intermediate_wait_result) {
-                                say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned slave on port $slave_port.");
+                                say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed on cloned replica on port $replica_port.");
                                 return STATUS_REPLICATION_FAILURE;
                         }
                         $intermediate_binlog_pos += 10000000;
                 } while (  $intermediate_binlog_pos <= $intermediate_binlog_size );
         }
 
-        say("Waiting for cloned slave to catch up..., file $final_binlog_file, pos $final_binlog_pos .");
-	my $final_wait_result = $slave_dbh->selectrow_array(
+        say("Waiting for cloned replica to catch up..., file $final_binlog_file, pos $final_binlog_pos .");
+	my $final_wait_result = $replica_dbh->selectrow_array(
 		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos)");
 
 	if (not defined $final_wait_result) {
-                say($terms->{pos_wait_func}."() failed. Cloned slave replication thread not running.");
+                say($terms->{pos_wait_func}."() failed. Cloned replica replication thread not running.");
                 return STATUS_REPLICATION_FAILURE;        }
-	
-	say("Cloned slave caught up.");
 
-        my @all_databases = @{$master_dbh->selectcol_arrayref("SHOW DATABASES")};
+	say("Cloned replica caught up.");
+
+        my @all_databases = @{$source_dbh->selectcol_arrayref("SHOW DATABASES")};
         my $databases_string = join(' ', grep { $_ !~ m{^(mysql|information_schema|performance_schema)$}sgio } @all_databases );
-		
-	my @dump_ports = ($master_port, $slave_port);
+
+	my @dump_ports = ($source_port, $replica_port);
 	my @dump_files;
 
 	foreach my $i (0..$#dump_ports) {
@@ -263,7 +263,7 @@ sub report {
 	my $diff_result = system("diff -u $dump_files[0] $dump_files[1]") >> 8;
 
 	if ($diff_result == 0) {
-		say("No differences were found between master and cloned slave.");
+		say("No differences were found between source and cloned replica.");
         }
 
         foreach my $dump_file (@dump_files) {

--- a/randgen/lib/GenTest/Reporter/MariadbGtidCrashSafety.pm
+++ b/randgen/lib/GenTest/Reporter/MariadbGtidCrashSafety.pm
@@ -66,8 +66,8 @@ sub monitor {
 
 	if (!$slave_dsn) {
 		# Running for the first time
-		my $slave_host = $reporter->serverInfo('slave_host');
-		my $slave_port = $reporter->serverInfo('slave_port');
+		my $slave_host = $reporter->serverInfo('replica_host');
+		my $slave_port = $reporter->serverInfo('replica_port');
 		$slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
 		$reporter->properties->servers->[1]->addServerOptions(['--skip-slave-start']);
 	}

--- a/randgen/lib/GenTest/Reporter/ReplicationAnalyzeTable.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationAnalyzeTable.pm
@@ -29,20 +29,20 @@ use GenTest::Reporter;
 sub monitor {
 	my $reporter = shift;
 
-	my $slave_host = $reporter->serverInfo('slave_host');
-	my $slave_port = $reporter->serverInfo('slave_port');
+	my $replica_host = $reporter->serverInfo('replica_host');
+	my $replica_port = $reporter->serverInfo('replica_port');
 
-	my $master_dsn = $reporter->dsn();
-	my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
+	my $source_dsn = $reporter->dsn();
+	my $replica_dsn = 'dbi:mysql:host='.$replica_host.':port='.$replica_port.':user=root';
 
-	my $slave_dbh = DBI->connect($slave_dsn);
-	
-	my $databases = $slave_dbh->selectcol_arrayref("SHOW DATABASES");
+	my $replica_dbh = DBI->connect($replica_dsn);
+
+	my $databases = $replica_dbh->selectcol_arrayref("SHOW DATABASES");
 	foreach my $database (@$databases) {
 		next if $database =~ m{^(mysql|information_schema|pbxt|performance_schema)$}sio;
-                my $tables = $slave_dbh->selectcol_arrayref("SHOW TABLES FROM `$database`");
+                my $tables = $replica_dbh->selectcol_arrayref("SHOW TABLES FROM `$database`");
                 foreach my $table (@$tables) {
-			$slave_dbh->do("ANALYZE TABLE `$database`.`$table`");
+			$replica_dbh->do("ANALYZE TABLE `$database`.`$table`");
 		}
 	}
 

--- a/randgen/lib/GenTest/Reporter/ReplicationConnectionKiller.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationConnectionKiller.pm
@@ -41,20 +41,20 @@ sub monitor {
 
 	my $dbh = DBI->connect($dsn);
 
-	my $slave_host = $reporter->serverInfo('slave_host');
-	my $master_port = $reporter->serverVariable('port');
+	my $replica_host = $reporter->serverInfo('replica_host');
+	my $source_port = $reporter->serverVariable('port');
 
 	# If interface is not specified, tcpkill will auto-pick the first available
 
-	my $interface = $slave_host eq '127.0.0.1' ? 'lo' : '';
+	my $interface = $replica_host eq '127.0.0.1' ? 'lo' : '';
 
-        my $slave_local = $dbh->selectrow_array("
+        my $replica_local = $dbh->selectrow_array("
 		SELECT HOST
 		FROM INFORMATION_SCHEMA.PROCESSLIST
 		WHERE COMMAND = 'Binlog Dump'
 	");
-	
-	my ($slave_local_host, $slave_local_port) = split (':', $slave_local);
+
+	my ($replica_local_host, $replica_local_port) = split (':', $replica_local);
 
 	$tcpkill_pid = fork();
 
@@ -65,7 +65,7 @@ sub monitor {
 		$tcpkill_pid = undef;
 		return(STATUS_OK);
 	} else {
-		my $command = "/usr/sbin/tcpkill -i $interface src host $slave_local_host and src port $slave_local_port and dst port $master_port";
+		my $command = "/usr/sbin/tcpkill -i $interface src host $replica_local_host and src port $replica_local_port and dst port $source_port";
 		say("Executing $command");
 		exec($command);
 		exit(STATUS_OK);

--- a/randgen/lib/GenTest/Reporter/ReplicationConsistency.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationConsistency.pm
@@ -24,6 +24,7 @@ use DBI;
 use GenTest;
 use GenTest::Constants;
 use GenTest::Reporter;
+use GenTest::ReplicationTerms qw(replicationTerms);
 
 my $reporter_called = 0;
 
@@ -37,7 +38,8 @@ sub report {
 	my $master_port = $reporter->serverVariable('port');
 	my $slave_port;
 
-	my $slave_info = $master_dbh->selectrow_arrayref("SHOW SLAVE HOSTS");
+	my $terms = replicationTerms($reporter->serverVariable('version'));
+	my $slave_info = $master_dbh->selectrow_arrayref($terms->{replicas});
 	if (defined $slave_info) {
 		$slave_port = $slave_info->[2];
 	} else {
@@ -49,11 +51,12 @@ sub report {
 
 	return STATUS_REPLICATION_FAILURE if not defined $slave_dbh;
 
-	$slave_dbh->do("START SLAVE");
+	$slave_dbh->do($terms->{start_replica});
 
 	#
-	# We call MASTER_POS_WAIT at 100K increments in order to avoid buildbot timeout in case
-	# one big MASTER_POS_WAIT would take more than 20 minutes.
+	# We call MASTER_POS_WAIT / SOURCE_POS_WAIT at 100K increments in order
+	# to avoid buildbot timeout in case one big wait would take more than
+	# 20 minutes.
 	#
 
 	my $sth_binlogs = $master_dbh->prepare("SHOW BINARY LOGS");
@@ -61,26 +64,28 @@ sub report {
 	while (my ($intermediate_binlog_file, $intermediate_binlog_size) = $sth_binlogs->fetchrow_array()) {
 		my $intermediate_binlog_pos = $intermediate_binlog_size < 10000000 ? $intermediate_binlog_size : 10000000;
 		do {
-			say("Executing intermediate MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos).");
-			my $intermediate_wait_result = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT('$intermediate_binlog_file',$intermediate_binlog_pos)");
+			say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos).");
+			my $intermediate_wait_result = $slave_dbh->selectrow_array(
+				"SELECT ".$terms->{pos_wait_func}."('$intermediate_binlog_file',$intermediate_binlog_pos)");
 			if (not defined $intermediate_wait_result) {
-				say("Intermediate MASTER_POS_WAIT('$intermediate_binlog_file', $intermediate_binlog_pos) failed in slave on port $slave_port. Slave replication thread not running.");
+				say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed in slave on port $slave_port. Slave replication thread not running.");
 				return STATUS_REPLICATION_FAILURE;
 			}
 			$intermediate_binlog_pos += 10000000;
 	        } while (  $intermediate_binlog_pos <= $intermediate_binlog_size );
 	}
 
-        my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array("SHOW MASTER STATUS");
+        my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
 
-	say("Executing final MASTER_POS_WAIT('$final_binlog_file', $final_binlog_pos.");
-	my $final_wait_result = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT('$final_binlog_file',$final_binlog_pos)");
+	say("Executing final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos.");
+	my $final_wait_result = $slave_dbh->selectrow_array(
+		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file',$final_binlog_pos)");
 
 	if (not defined $final_wait_result) {
-		say("Final MASTER_POS_WAIT('$final_binlog_file', $final_binlog_pos) failed in slave on port $slave_port. Slave replication thread not running.");
+		say("Final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos) failed in slave on port $slave_port. Slave replication thread not running.");
 		return STATUS_REPLICATION_FAILURE;
 	} else {
-		say("Final MASTER_POS_WAIT('$final_binlog_file', $final_binlog_pos) complete.");
+		say("Final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos) complete.");
 	}
 
 	my @all_databases = @{$master_dbh->selectcol_arrayref("SHOW DATABASES")};

--- a/randgen/lib/GenTest/Reporter/ReplicationConsistency.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationConsistency.pm
@@ -34,24 +34,24 @@ sub report {
 	return STATUS_WONT_HANDLE if $reporter_called == 1;
 	$reporter_called = 1;
 
-	my $master_dbh = DBI->connect($reporter->dsn(), undef, undef, {PrintError => 0});
-	my $master_port = $reporter->serverVariable('port');
-	my $slave_port;
+	my $source_dbh = DBI->connect($reporter->dsn(), undef, undef, {PrintError => 0});
+	my $source_port = $reporter->serverVariable('port');
+	my $replica_port;
 
 	my $terms = replicationTerms($reporter->serverVariable('version'));
-	my $slave_info = $master_dbh->selectrow_arrayref($terms->{replicas});
-	if (defined $slave_info) {
-		$slave_port = $slave_info->[2];
+	my $replica_info = $source_dbh->selectrow_arrayref($terms->{replicas});
+	if (defined $replica_info) {
+		$replica_port = $replica_info->[2];
 	} else {
-		$slave_port = $master_port + 2;
+		$replica_port = $source_port + 2;
 	}
 
-        my $slave_dsn = "dbi:mysql:host=127.0.0.1:port=".$slave_port.":user=root";
-        my $slave_dbh = DBI->connect($slave_dsn, undef, undef, { PrintError => 1 } );
+        my $replica_dsn = "dbi:mysql:host=127.0.0.1:port=".$replica_port.":user=root";
+        my $replica_dbh = DBI->connect($replica_dsn, undef, undef, { PrintError => 1 } );
 
-	return STATUS_REPLICATION_FAILURE if not defined $slave_dbh;
+	return STATUS_REPLICATION_FAILURE if not defined $replica_dbh;
 
-	$slave_dbh->do($terms->{start_replica});
+	$replica_dbh->do($terms->{start_replica});
 
 	#
 	# We call MASTER_POS_WAIT / SOURCE_POS_WAIT at 100K increments in order
@@ -59,39 +59,39 @@ sub report {
 	# 20 minutes.
 	#
 
-	my $sth_binlogs = $master_dbh->prepare("SHOW BINARY LOGS");
+	my $sth_binlogs = $source_dbh->prepare("SHOW BINARY LOGS");
 	$sth_binlogs->execute();
 	while (my ($intermediate_binlog_file, $intermediate_binlog_size) = $sth_binlogs->fetchrow_array()) {
 		my $intermediate_binlog_pos = $intermediate_binlog_size < 10000000 ? $intermediate_binlog_size : 10000000;
 		do {
 			say("Executing intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos).");
-			my $intermediate_wait_result = $slave_dbh->selectrow_array(
+			my $intermediate_wait_result = $replica_dbh->selectrow_array(
 				"SELECT ".$terms->{pos_wait_func}."('$intermediate_binlog_file',$intermediate_binlog_pos)");
 			if (not defined $intermediate_wait_result) {
-				say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed in slave on port $slave_port. Slave replication thread not running.");
+				say("Intermediate ".$terms->{pos_wait_func}."('$intermediate_binlog_file', $intermediate_binlog_pos) failed in replica on port $replica_port. Replica replication thread not running.");
 				return STATUS_REPLICATION_FAILURE;
 			}
 			$intermediate_binlog_pos += 10000000;
 	        } while (  $intermediate_binlog_pos <= $intermediate_binlog_size );
 	}
 
-        my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
+        my ($final_binlog_file, $final_binlog_pos) = $source_dbh->selectrow_array($terms->{binlog_status});
 
 	say("Executing final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos).");
-	my $final_wait_result = $slave_dbh->selectrow_array(
+	my $final_wait_result = $replica_dbh->selectrow_array(
 		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file',$final_binlog_pos)");
 
 	if (not defined $final_wait_result) {
-		say("Final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos) failed in slave on port $slave_port. Slave replication thread not running.");
+		say("Final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos) failed in replica on port $replica_port. Replica replication thread not running.");
 		return STATUS_REPLICATION_FAILURE;
 	} else {
 		say("Final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos) complete.");
 	}
 
-	my @all_databases = @{$master_dbh->selectcol_arrayref("SHOW DATABASES")};
+	my @all_databases = @{$source_dbh->selectcol_arrayref("SHOW DATABASES")};
 	my $databases_string = join(' ', grep { $_ !~ m{^(mysql|information_schema|performance_schema)$}sgio } @all_databases );
 	
-	my @dump_ports = ($master_port , $slave_port);
+	my @dump_ports = ($source_port , $replica_port);
 	my @dump_files;
 
 	foreach my $i (0..$#dump_ports) {

--- a/randgen/lib/GenTest/Reporter/ReplicationConsistency.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationConsistency.pm
@@ -77,7 +77,7 @@ sub report {
 
         my ($final_binlog_file, $final_binlog_pos) = $master_dbh->selectrow_array($terms->{binlog_status});
 
-	say("Executing final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos.");
+	say("Executing final ".$terms->{pos_wait_func}."('$final_binlog_file', $final_binlog_pos).");
 	my $final_wait_result = $slave_dbh->selectrow_array(
 		"SELECT ".$terms->{pos_wait_func}."('$final_binlog_file',$final_binlog_pos)");
 

--- a/randgen/lib/GenTest/Reporter/ReplicationSemiSync.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationSemiSync.pm
@@ -40,6 +40,7 @@ use strict;
 use GenTest;
 use GenTest::Reporter;
 use GenTest::Constants;
+use GenTest::ReplicationTerms qw(replicationTerms);
 
 my $rpl_semi_sync_master_timeout = 10;
 
@@ -49,6 +50,7 @@ sub monitor {
 	say("GenTest::Reporter::ReplicationSemiSync: Test cycle starting.");
 
 	my $prng = $reporter->prng();
+	my $terms = replicationTerms($reporter->serverVariable('version'));
 
     my $slave_host;
     my $slave_port;
@@ -73,7 +75,7 @@ sub monitor {
 	$slave_dbh->do("SET GLOBAL rpl_semi_sync_slave_enabled = 1");
 	$slave_dbh->do("SET GLOBAL rpl_semi_sync_slave_trace_level = 80");
 
-	return STATUS_REPLICATION_FAILURE if waitForSlave($master_dbh, $slave_dbh, 1);
+	return STATUS_REPLICATION_FAILURE if waitForSlave($master_dbh, $slave_dbh, 1, $terms);
 # 	sleep(1);
 
 # 	my ($unused2, $rpl_semi_sync_master_status_first) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
@@ -151,13 +153,13 @@ sub monitor {
 	}
 	
 	say("GenTest::Reporter::ReplicationSemiSync: Starting slave IO thread.");
-	$slave_dbh->do("START SLAVE IO_THREAD");
+	$slave_dbh->do($terms->{start_replica_io});
 
 	#
 	# Make sure master and slave can reconcile and semisync will be turned on again
 	#
 
-	return STATUS_REPLICATION_FAILURE if waitForSlave($master_dbh, $slave_dbh, 0);
+	return STATUS_REPLICATION_FAILURE if waitForSlave($master_dbh, $slave_dbh, 0, $terms);
 # 	sleep(1);
 
 # 	my ($unused7, $rpl_semi_sync_master_status_last) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
@@ -176,15 +178,16 @@ sub type {
 }
 
 sub isSlaveBehind {
-	my ($master_dbh, $slave_dbh) = @_;
+	my ($master_dbh, $slave_dbh, $terms) = @_;
 
 	my $binlogs = $master_dbh->selectall_arrayref("SHOW BINARY LOGS");
 	my ($last_log_name, $last_log_pos) = ($binlogs->[$#$binlogs]->[0], $binlogs->[$#$binlogs]->[1]);
 	my ($last_log_id) = $last_log_name =~ m{(\d+)}sgio;
 	say("Master: last_log_name = $last_log_name; last_log_pos = $last_log_pos; $last_log_id = $last_log_id.");
 			
-	my $slave_status = $slave_dbh->selectrow_arrayref("SHOW SLAVE STATUS");
-	my ($master_log_file, $read_master_log_pos) = ($slave_status->[5], $slave_status->[6]);
+	my $slave_status = $slave_dbh->selectrow_hashref($terms->{replica_status});
+	my $master_log_file = $slave_status->{Source_Log_File} // $slave_status->{Master_Log_File};
+	my $read_master_log_pos = $slave_status->{Read_Source_Log_Pos} // $slave_status->{Read_Master_Log_Pos};
 	my ($master_log_id) = $master_log_file =~ m{(\d+)}sgio;
 	say("GenTest::Reporter::ReplicationSemiSync: slave: master_log_file = $master_log_file; read_master_log_pos = $read_master_log_pos; master_log_id = $master_log_id.");
 	if ( 
@@ -198,26 +201,23 @@ sub isSlaveBehind {
 }
 
 sub waitForSlave {
-	my ($master_dbh, $slave_dbh, $stop_slave) = @_;
+	my ($master_dbh, $slave_dbh, $stop_slave, $terms) = @_;
 
 	say("GenTest::Reporter::ReplicationSemiSync: Flushing tables with read lock on master...");
 	$master_dbh->do("FLUSH NO_WRITE_TO_BINLOG TABLES WITH READ LOCK");
 	say("GenTest::Reporter::ReplicationSemiSync: ... flushed.");
 
-	my ($file, $pos) = $master_dbh->selectrow_array("SHOW MASTER STATUS");
+	my ($file, $pos) = $master_dbh->selectrow_array($terms->{binlog_status});
 
 	if (($file eq '') || ($pos eq '')) {
-		 say("GenTest::Reporter::ReplicationSemiSync: SHOW MASTER STATUS failed.");
+		 say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{binlog_status}." failed.");
 		 return STATUS_REPLICATION_FAILURE;
 	}
 
 	say("GenTest::Reporter::ReplicationSemiSync: Waiting for slave...");
-	#say("SHOW MASTER STATUS: " . $file . ", " . $pos);
-	my $wait_status = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT(?, ?)", undef, $file, $pos);
+	my $wait_status = $slave_dbh->selectrow_array(
+		"SELECT ".$terms->{pos_wait_func}."(?, ?)", undef, $file, $pos);
 	say("GenTest::Reporter::ReplicationSemiSync: ... slave caught up with master.");
-
-	#my ($new_file, $new_pos) = $master_dbh->selectrow_array("SHOW MASTER STATUS");
-	#say("SHOW MASTER STATUS: " . $new_file . ", " . $new_pos);
 
 	my ($unused2, $rpl_semi_sync_master_status) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
 	if (not $rpl_semi_sync_master_status eq 'ON') {
@@ -230,14 +230,14 @@ sub waitForSlave {
 	    say("GenTest::Reporter::ReplicationSemiSync: Flushed status.");
 	    $master_dbh->do("SET GLOBAL rpl_semi_sync_master_timeout = ".($rpl_semi_sync_master_timeout * 1000));
 	    say("GenTest::Reporter::ReplicationSemiSync: stopping slave IO thread.");
-	    $slave_dbh->do("STOP SLAVE IO_THREAD");
+	    $slave_dbh->do($terms->{stop_replica_io});
 	    say("GenTest::Reporter::ReplicationSemiSync: stopped slave IO thread.");
 	}
 
 	$master_dbh->do("UNLOCK TABLES");
 
 	if (not defined $wait_status) {
-		say("GenTest::Reporter::ReplicationSemiSync: MASTER_POS_WAIT() has failed. Slave SQL thread has likely stopped.");
+		say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{pos_wait_func}."() has failed. Slave SQL thread has likely stopped.");
 		return STATUS_REPLICATION_FAILURE;
 	}
 	return 0;

--- a/randgen/lib/GenTest/Reporter/ReplicationSemiSync.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationSemiSync.pm
@@ -20,16 +20,16 @@ package GenTest::Reporter::ReplicationSemiSync;
 #
 # The purpose of this Reporter is to test Semi-synchronous replication as follows:
 #
-#  At every monitoring cycle, we issue an adverse event against the slave or the master/slave connection and then:
+#  At every monitoring cycle, we issue an adverse event against the replica or the source/replica connection and then:
 #
-# 1. Check that the slave IO thread is up to date with the master
+# 1. Check that the replica IO thread is up to date with the source
 #
 # 2A. We wait for 1/2 of the timeout period, and then we check various counters to see that no transactions
-#    have committed while the slave was not available OR 
+#    have committed while the replica was not available OR
 #
 # 2B. We wait for more than the timeout period and then we check that some transactions have moved forward
 #
-# 3. We restart replication in order to allow the slave to catch up, and check that the master is back to
+# 3. We restart replication in order to allow the replica to catch up, and check that the source is back to
 #    semisync replication
 #
 
@@ -42,7 +42,7 @@ use GenTest::Reporter;
 use GenTest::Constants;
 use GenTest::ReplicationTerms qw(replicationTerms);
 
-my $rpl_semi_sync_master_timeout = 10;
+my $rpl_semi_sync_source_timeout = 10;
 
 sub monitor {
 	my $reporter = shift;
@@ -52,30 +52,30 @@ sub monitor {
 	my $prng = $reporter->prng();
 	my $terms = replicationTerms($reporter->serverVariable('version'));
 
-    my $slave_host;
-    my $slave_port;
-    my $master_dsn;
+    my $replica_host;
+    my $replica_port;
+    my $source_dsn;
     if (defined $ENV{RQG_CALLBACK}) {
-        $slave_host = $ENV{RQG_SLAVE_HOST};
-        $slave_port = $ENV{RQG_SLAVE_PORT};
-        $master_dsn = 'dbi:mysql:host='.$ENV{RQG_MASTER_HOST}.':port='.$ENV{RQG_MASTER_PORT}.':user=root';
+        $replica_host = $ENV{RQG_SLAVE_HOST};
+        $replica_port = $ENV{RQG_SLAVE_PORT};
+        $source_dsn = 'dbi:mysql:host='.$ENV{RQG_MASTER_HOST}.':port='.$ENV{RQG_MASTER_PORT}.':user=root';
     } else {
-        $slave_host = $reporter->serverInfo('slave_host');
-        $slave_port = $reporter->serverInfo('slave_port');
-        $master_dsn = $reporter->dsn();
+        $replica_host = $reporter->serverInfo('replica_host');
+        $replica_port = $reporter->serverInfo('replica_port');
+        $source_dsn = $reporter->dsn();
     }
 
-	my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
+	my $replica_dsn = 'dbi:mysql:host='.$replica_host.':port='.$replica_port.':user=root';
 
-	my $slave_dbh = DBI->connect($slave_dsn);
-	my $master_dbh = DBI->connect($master_dsn);
+	my $replica_dbh = DBI->connect($replica_dsn);
+	my $source_dbh = DBI->connect($source_dsn);
 
-	$master_dbh->do("SET GLOBAL rpl_semi_sync_master_enabled = 1");
-	$master_dbh->do("SET GLOBAL rpl_semi_sync_master_trace_level = 80");
-	$slave_dbh->do("SET GLOBAL rpl_semi_sync_slave_enabled = 1");
-	$slave_dbh->do("SET GLOBAL rpl_semi_sync_slave_trace_level = 80");
+	$source_dbh->do("SET GLOBAL ".$terms->{semisync_source_enabled}." = 1");
+	$source_dbh->do("SET GLOBAL ".$terms->{semisync_source_trace_level}." = 80");
+	$replica_dbh->do("SET GLOBAL ".$terms->{semisync_replica_enabled}." = 1");
+	$replica_dbh->do("SET GLOBAL ".$terms->{semisync_replica_trace_level}." = 80");
 
-	return STATUS_REPLICATION_FAILURE if waitForSlave($master_dbh, $slave_dbh, 1, $terms);
+	return STATUS_REPLICATION_FAILURE if waitForReplica($source_dbh, $replica_dbh, 1, $terms);
 # 	sleep(1);
 
 # 	my ($unused2, $rpl_semi_sync_master_status_first) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
@@ -106,60 +106,60 @@ sub monitor {
 
 	# Pick a sleep interval that is either more or less than the semisync timeout
 
-	my $sleep_interval = $prng->int(0, 1) == 1 ? ($rpl_semi_sync_master_timeout * 2) : 5;
+	my $sleep_interval = $prng->int(0, 1) == 1 ? ($rpl_semi_sync_source_timeout * 2) : 5;
 	say("GenTest::Reporter::ReplicationSemiSync: Sleeping for $sleep_interval seconds.");
 	sleep($sleep_interval);
 
-	my ($unused4, $rpl_semi_sync_master_yes_tx) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx'");
-	my ($unused5, $rpl_semi_sync_master_no_tx) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_no_tx'");
-	my ($unused6, $rpl_semi_sync_master_status_after) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
+	my ($unused4, $rpl_semi_sync_source_yes_tx) = $source_dbh->selectrow_array("SHOW STATUS LIKE '".$terms->{semisync_source_yes_tx}."'");
+	my ($unused5, $rpl_semi_sync_source_no_tx) = $source_dbh->selectrow_array("SHOW STATUS LIKE '".$terms->{semisync_source_no_tx}."'");
+	my ($unused6, $rpl_semi_sync_source_status_after) = $source_dbh->selectrow_array("SHOW STATUS LIKE '".$terms->{semisync_source_status}."'");
 
 	#
 	# If we slept more than the semisync timeout, then we can expect that transactions have been committed
 	# If we slept less, then no transactions should have committed
 	#
 
-	if ($sleep_interval > $rpl_semi_sync_master_timeout) {
-                if ($rpl_semi_sync_master_status_after eq 'ON') {
-                        say("GenTest::Reporter::ReplicationSemiSync: rpl_semi_sync_master_status = ON even after stopping for longer than the timeout.");
+	if ($sleep_interval > $rpl_semi_sync_source_timeout) {
+                if ($rpl_semi_sync_source_status_after eq 'ON') {
+                        say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{semisync_source_status}." = ON even after stopping for longer than the timeout.");
                         return STATUS_REPLICATION_FAILURE;
-                } elsif ($rpl_semi_sync_master_no_tx == 0) {
-			say("GenTest::Reporter::ReplicationSemiSync: Transactions were not committed asynchronously while slave was stopped for longer than the timeout.");
-			say("GenTest::Reporter::ReplicationSemiSync: rpl_semi_sync_master_no_tx = $rpl_semi_sync_master_no_tx;");
-		} elsif ($rpl_semi_sync_master_yes_tx > 0) {
-			say("GenTest::Reporter::ReplicationSemiSync: Transactions were committed semisynchronously while slave was stopped longer than the timeout.");
-			say("GenTest::Reporter::ReplicationSemiSync: rpl_semi_sync_master_yes_tx = $rpl_semi_sync_master_yes_tx;");
+                } elsif ($rpl_semi_sync_source_no_tx == 0) {
+			say("GenTest::Reporter::ReplicationSemiSync: Transactions were not committed asynchronously while replica was stopped for longer than the timeout.");
+			say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{semisync_source_no_tx}." = $rpl_semi_sync_source_no_tx;");
+		} elsif ($rpl_semi_sync_source_yes_tx > 0) {
+			say("GenTest::Reporter::ReplicationSemiSync: Transactions were committed semisynchronously while replica was stopped longer than the timeout.");
+			say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{semisync_source_yes_tx}." = $rpl_semi_sync_source_yes_tx;");
 			return STATUS_REPLICATION_FAILURE;
 		}
 	} else {
 
-#		jasonh says that this condition is not guaranteed - if we detect a slave problem, we abort immediately and do not bother
+#		jasonh says that this condition is not guaranteed - if we detect a replica problem, we abort immediately and do not bother
 #		to wait for the full timeout
 #
-		if ($rpl_semi_sync_master_status_after eq 'OFF') {
-			say("GenTest::Reporter::ReplicationSemiSync: rpl_semi_sync_master_status = OFF even after stopping for less than the timeout.");
+		if ($rpl_semi_sync_source_status_after eq 'OFF') {
+			say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{semisync_source_status}." = OFF even after stopping for less than the timeout.");
 			return STATUS_REPLICATION_FAILURE;
-		} elsif ($rpl_semi_sync_master_no_tx > 0) {
-			say("GenTest::Reporter::ReplicationSemiSync: Transactions were committed asynchronously while slave was stopped for less than the timeout.");
-			say("GenTest::Reporter::ReplicationSemiSync: rpl_semi_sync_master_no_tx = $rpl_semi_sync_master_no_tx;");
+		} elsif ($rpl_semi_sync_source_no_tx > 0) {
+			say("GenTest::Reporter::ReplicationSemiSync: Transactions were committed asynchronously while replica was stopped for less than the timeout.");
+			say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{semisync_source_no_tx}." = $rpl_semi_sync_source_no_tx;");
 			return STATUS_REPLICATION_FAILURE;
-		} elsif ($rpl_semi_sync_master_yes_tx > 0) {
-			say("GenTest::Reporter::ReplicationSemiSync: Transactions were committed semisynchronously while slave was stopped for less than the timeout.");
-			say("GenTest::Reporter::ReplicationSemiSync: rpl_semi_sync_master_yes_tx = $rpl_semi_sync_master_yes_tx;");
+		} elsif ($rpl_semi_sync_source_yes_tx > 0) {
+			say("GenTest::Reporter::ReplicationSemiSync: Transactions were committed semisynchronously while replica was stopped for less than the timeout.");
+			say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{semisync_source_yes_tx}." = $rpl_semi_sync_source_yes_tx;");
 			return STATUS_REPLICATION_FAILURE;
 		} else {
-#			return STATUS_REPLICATION_FAILURE if isSlaveBehind($master_dbh, $slave_dbh);
+#			return STATUS_REPLICATION_FAILURE if isReplicaBehind($source_dbh, $replica_dbh);
 		}
 	}
-	
-	say("GenTest::Reporter::ReplicationSemiSync: Starting slave IO thread.");
-	$slave_dbh->do($terms->{start_replica_io});
+
+	say("GenTest::Reporter::ReplicationSemiSync: Starting replica IO thread.");
+	$replica_dbh->do($terms->{start_replica_io});
 
 	#
-	# Make sure master and slave can reconcile and semisync will be turned on again
+	# Make sure source and replica can reconcile and semisync will be turned on again
 	#
 
-	return STATUS_REPLICATION_FAILURE if waitForSlave($master_dbh, $slave_dbh, 0, $terms);
+	return STATUS_REPLICATION_FAILURE if waitForReplica($source_dbh, $replica_dbh, 0, $terms);
 # 	sleep(1);
 
 # 	my ($unused7, $rpl_semi_sync_master_status_last) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
@@ -177,67 +177,67 @@ sub type {
 	return REPORTER_TYPE_PERIODIC;
 }
 
-sub isSlaveBehind {
-	my ($master_dbh, $slave_dbh, $terms) = @_;
+sub isReplicaBehind {
+	my ($source_dbh, $replica_dbh, $terms) = @_;
 
-	my $binlogs = $master_dbh->selectall_arrayref("SHOW BINARY LOGS");
+	my $binlogs = $source_dbh->selectall_arrayref("SHOW BINARY LOGS");
 	my ($last_log_name, $last_log_pos) = ($binlogs->[$#$binlogs]->[0], $binlogs->[$#$binlogs]->[1]);
 	my ($last_log_id) = $last_log_name =~ m{(\d+)}sgio;
-	say("Master: last_log_name = $last_log_name; last_log_pos = $last_log_pos; $last_log_id = $last_log_id.");
-			
-	my $slave_status = $slave_dbh->selectrow_hashref($terms->{replica_status});
-	my $master_log_file = $slave_status->{Source_Log_File} // $slave_status->{Master_Log_File};
-	my $read_master_log_pos = $slave_status->{Read_Source_Log_Pos} // $slave_status->{Read_Master_Log_Pos};
-	my ($master_log_id) = $master_log_file =~ m{(\d+)}sgio;
-	say("GenTest::Reporter::ReplicationSemiSync: slave: master_log_file = $master_log_file; read_master_log_pos = $read_master_log_pos; master_log_id = $master_log_id.");
-	if ( 
-		($last_log_id < $master_log_id) ||
-		($last_log_id == $master_log_id) && ($last_log_pos > $read_master_log_pos)
+	say("Source: last_log_name = $last_log_name; last_log_pos = $last_log_pos; $last_log_id = $last_log_id.");
+
+	my $replica_status = $replica_dbh->selectrow_hashref($terms->{replica_status});
+	my $source_log_file = $replica_status->{Source_Log_File} // $replica_status->{Master_Log_File};
+	my $read_source_log_pos = $replica_status->{Read_Source_Log_Pos} // $replica_status->{Read_Master_Log_Pos};
+	my ($source_log_id) = $source_log_file =~ m{(\d+)}sgio;
+	say("GenTest::Reporter::ReplicationSemiSync: replica: source_log_file = $source_log_file; read_source_log_pos = $read_source_log_pos; source_log_id = $source_log_id.");
+	if (
+		($last_log_id < $source_log_id) ||
+		($last_log_id == $source_log_id) && ($last_log_pos > $read_source_log_pos)
 	) {
-		my ($unused, $rpl_semi_sync_master_status) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
-		say("GenTest::Reporter::ReplicationSemiSync: Slave has lagged behind while Rpl_semi_sync_master_status = $rpl_semi_sync_master_status.");
+		my ($unused, $rpl_semi_sync_source_status) = $source_dbh->selectrow_array("SHOW STATUS LIKE '".$terms->{semisync_source_status}."'");
+		say("GenTest::Reporter::ReplicationSemiSync: Replica has lagged behind while ".$terms->{semisync_source_status}." = $rpl_semi_sync_source_status.");
 		return STATUS_REPLICATION_FAILURE;
 	}
 }
 
-sub waitForSlave {
-	my ($master_dbh, $slave_dbh, $stop_slave, $terms) = @_;
+sub waitForReplica {
+	my ($source_dbh, $replica_dbh, $stop_replica, $terms) = @_;
 
-	say("GenTest::Reporter::ReplicationSemiSync: Flushing tables with read lock on master...");
-	$master_dbh->do("FLUSH NO_WRITE_TO_BINLOG TABLES WITH READ LOCK");
+	say("GenTest::Reporter::ReplicationSemiSync: Flushing tables with read lock on source...");
+	$source_dbh->do("FLUSH NO_WRITE_TO_BINLOG TABLES WITH READ LOCK");
 	say("GenTest::Reporter::ReplicationSemiSync: ... flushed.");
 
-	my ($file, $pos) = $master_dbh->selectrow_array($terms->{binlog_status});
+	my ($file, $pos) = $source_dbh->selectrow_array($terms->{binlog_status});
 
 	if (($file eq '') || ($pos eq '')) {
 		 say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{binlog_status}." failed.");
 		 return STATUS_REPLICATION_FAILURE;
 	}
 
-	say("GenTest::Reporter::ReplicationSemiSync: Waiting for slave...");
-	my $wait_status = $slave_dbh->selectrow_array(
+	say("GenTest::Reporter::ReplicationSemiSync: Waiting for replica...");
+	my $wait_status = $replica_dbh->selectrow_array(
 		"SELECT ".$terms->{pos_wait_func}."(?, ?)", undef, $file, $pos);
-	say("GenTest::Reporter::ReplicationSemiSync: ... slave caught up with master.");
+	say("GenTest::Reporter::ReplicationSemiSync: ... replica caught up with source.");
 
-	my ($unused2, $rpl_semi_sync_master_status) = $master_dbh->selectrow_array("SHOW STATUS LIKE 'Rpl_semi_sync_master_status'");
-	if (not $rpl_semi_sync_master_status eq 'ON') {
-	    say("GenTest::Reporter::ReplicationSemiSync: Master has failed to return to semisync replication even after the slave has caught up.");
+	my ($unused2, $rpl_semi_sync_source_status) = $source_dbh->selectrow_array("SHOW STATUS LIKE '".$terms->{semisync_source_status}."'");
+	if (not $rpl_semi_sync_source_status eq 'ON') {
+	    say("GenTest::Reporter::ReplicationSemiSync: Source has failed to return to semisync replication even after the replica has caught up.");
 	    return STATUS_REPLICATION_FAILURE;
 	}
 
-	if ($stop_slave) {
-	    $master_dbh->do("FLUSH NO_WRITE_TO_BINLOG STATUS");
+	if ($stop_replica) {
+	    $source_dbh->do("FLUSH NO_WRITE_TO_BINLOG STATUS");
 	    say("GenTest::Reporter::ReplicationSemiSync: Flushed status.");
-	    $master_dbh->do("SET GLOBAL rpl_semi_sync_master_timeout = ".($rpl_semi_sync_master_timeout * 1000));
-	    say("GenTest::Reporter::ReplicationSemiSync: stopping slave IO thread.");
-	    $slave_dbh->do($terms->{stop_replica_io});
-	    say("GenTest::Reporter::ReplicationSemiSync: stopped slave IO thread.");
+	    $source_dbh->do("SET GLOBAL ".$terms->{semisync_source_timeout}." = ".($rpl_semi_sync_source_timeout * 1000));
+	    say("GenTest::Reporter::ReplicationSemiSync: stopping replica IO thread.");
+	    $replica_dbh->do($terms->{stop_replica_io});
+	    say("GenTest::Reporter::ReplicationSemiSync: stopped replica IO thread.");
 	}
 
-	$master_dbh->do("UNLOCK TABLES");
+	$source_dbh->do("UNLOCK TABLES");
 
 	if (not defined $wait_status) {
-		say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{pos_wait_func}."() has failed. Slave SQL thread has likely stopped.");
+		say("GenTest::Reporter::ReplicationSemiSync: ".$terms->{pos_wait_func}."() has failed. Replica SQL thread has likely stopped.");
 		return STATUS_REPLICATION_FAILURE;
 	}
 	return 0;

--- a/randgen/lib/GenTest/Reporter/ReplicationThreadRestarter.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationThreadRestarter.pm
@@ -31,11 +31,11 @@ sub monitor {
 
 	my $prng = $reporter->prng();
 
-	my $slave_host = $reporter->serverInfo('slave_host');
-	my $slave_port = $reporter->serverInfo('slave_port');
+	my $replica_host = $reporter->serverInfo('replica_host');
+	my $replica_port = $reporter->serverInfo('replica_port');
 
-	my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
-	my $slave_dbh = DBI->connect($slave_dsn);
+	my $replica_dsn = 'dbi:mysql:host='.$replica_host.':port='.$replica_port.':user=root';
+	my $replica_dbh = DBI->connect($replica_dsn);
 
 	my $verb = $prng->arrayElement(['START','STOP']);
 	my $threads = $prng->arrayElement([
@@ -48,10 +48,10 @@ sub monitor {
 
 	my $query = $verb.' SLAVE '.$threads;
 
-	if (defined $slave_dbh) {
-		$slave_dbh->do($query);
-		if ($slave_dbh->err()) {
-			say("Query: $query failed: ".$slave_dbh->errstr());
+	if (defined $replica_dbh) {
+		$replica_dbh->do($query);
+		if ($replica_dbh->err()) {
+			say("Query: $query failed: ".$replica_dbh->errstr());
 			return STATUS_REPLICATION_FAILURE;
 		} else {
 			return STATUS_OK;

--- a/randgen/lib/GenTest/Reporter/ReplicationThreadRestarter.pm
+++ b/randgen/lib/GenTest/Reporter/ReplicationThreadRestarter.pm
@@ -24,6 +24,7 @@ use strict;
 use GenTest;
 use GenTest::Reporter;
 use GenTest::Constants;
+use GenTest::ReplicationTerms qw(replicationTerms);
 
 sub monitor {
 
@@ -37,6 +38,8 @@ sub monitor {
 	my $replica_dsn = 'dbi:mysql:host='.$replica_host.':port='.$replica_port.':user=root';
 	my $replica_dbh = DBI->connect($replica_dsn);
 
+	my $terms = replicationTerms($reporter->serverVariable('version'));
+
 	my $verb = $prng->arrayElement(['START','STOP']);
 	my $threads = $prng->arrayElement([
 		'',
@@ -46,7 +49,7 @@ sub monitor {
 		'SQL_THREAD'
 	]);
 
-	my $query = $verb.' SLAVE '.$threads;
+	my $query = $verb.' '.$terms->{replica_keyword}.' '.$threads;
 
 	if (defined $replica_dbh) {
 		$replica_dbh->do($query);

--- a/randgen/lib/GenTest/Validator/ReplicationSlaveStatus.pm
+++ b/randgen/lib/GenTest/Validator/ReplicationSlaveStatus.pm
@@ -27,17 +27,11 @@ use GenTest;
 use GenTest::Constants;
 use GenTest::Result;
 use GenTest::Validator;
-use GenTest::Executor::MySQL;
 
-# Previously hardcoded positional indices into SHOW SLAVE STATUS output
-# (19/35/38) -- fragile by construction, since MySQL has added columns to
-# this output across versions, and confirmed actually wrong on a live
-# Percona Server 9.7 build (Last_IO_Error sits at position 35, Last_SQL_Error
-# at 37, not 38/35). Switched to name-based access below instead: MySQL kept
-# the column names Last_Error/Last_IO_Error/Last_SQL_Error unchanged when it
-# renamed the statement itself to SHOW REPLICA STATUS in 8.0.23+, so
-# selectrow_hashref() works correctly regardless of which statement variant
-# ran, with no version-dependent column positions to track.
+# Error columns are read by name via selectrow_hashref(). Positional indices
+# into SHOW SLAVE/REPLICA STATUS have shifted across MySQL versions; the
+# Last_*_Error column names themselves were kept stable through the
+# SOURCE/REPLICA rename.
 
 sub init {
 	my ($validator, $executors) = @_;
@@ -55,6 +49,10 @@ sub init {
 	my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
 
 	my $slave_dbh = DBI->connect($slave_dsn, undef, undef, { PrintError => 0 });
+	if (not defined $slave_dbh) {
+		say("Unable to connect to replica at $slave_dsn");
+		return STATUS_REPLICATION_FAILURE;
+	}
 	$validator->setDbh($slave_dbh);
 	return STATUS_OK;
 }
@@ -64,16 +62,18 @@ sub validate {
 
 	my $master_executor = $executors->[0];
 
-	# init() may have failed to obtain a slave connection (e.g. slaveInfo()
-	# found no registered replica) without that being surfaced here -- guard
-	# rather than crash the whole worker on ->selectrow_hashref() against an
-	# undef $dbh.
 	my $dbh = $validator->dbh();
-	return STATUS_WONT_HANDLE if not defined $dbh;
+	if (not defined $dbh) {
+		say("Replica connection is gone; cannot check replication status.");
+		return STATUS_REPLICATION_FAILURE;
+	}
 
-	my $modern = GenTest::Executor::MySQL::_usesModernReplicationSyntax($master_executor->version());
-	my $slave_status = $dbh->selectrow_hashref($modern ? "SHOW REPLICA STATUS" : "SHOW SLAVE STATUS");
-	return STATUS_WONT_HANDLE if not defined $slave_status;
+	my $terms = $master_executor->replicationTerms();
+	my $slave_status = $dbh->selectrow_hashref($terms->{replica_status});
+	if (not defined $slave_status) {
+		say("SHOW REPLICA/SLAVE STATUS returned no data.");
+		return STATUS_REPLICATION_FAILURE;
+	}
 
 	for my $error_column (qw(Last_IO_Error Last_SQL_Error Last_Error)) {
 		if (defined $slave_status->{$error_column} && $slave_status->{$error_column} ne '') {

--- a/randgen/lib/GenTest/Validator/ReplicationSlaveStatus.pm
+++ b/randgen/lib/GenTest/Validator/ReplicationSlaveStatus.pm
@@ -37,23 +37,23 @@ sub init {
 	my ($validator, $executors) = @_;
 	my $master_executor = $executors->[0];
 
-	my ($slave_host, $slave_port) = $master_executor->slaveInfo();
+	my ($replica_host, $replica_port) = $master_executor->replicaInfo();
 
 	if (
-		($slave_host eq '') ||
-		($slave_port eq '')
+		($replica_host eq '') ||
+		($replica_port eq '')
 	) {
 		say("SHOW REPLICAS / SHOW SLAVE HOSTS returned no data.");
 		return STATUS_REPLICATION_FAILURE;
 	}
-	my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
+	my $replica_dsn = 'dbi:mysql:host='.$replica_host.':port='.$replica_port.':user=root';
 
-	my $slave_dbh = DBI->connect($slave_dsn, undef, undef, { PrintError => 0 });
-	if (not defined $slave_dbh) {
-		say("Unable to connect to replica at $slave_dsn");
+	my $replica_dbh = DBI->connect($replica_dsn, undef, undef, { PrintError => 0 });
+	if (not defined $replica_dbh) {
+		say("Unable to connect to replica at $replica_dsn");
 		return STATUS_REPLICATION_FAILURE;
 	}
-	$validator->setDbh($slave_dbh);
+	$validator->setDbh($replica_dbh);
 	return STATUS_OK;
 }
 
@@ -69,15 +69,15 @@ sub validate {
 	}
 
 	my $terms = $master_executor->replicationTerms();
-	my $slave_status = $dbh->selectrow_hashref($terms->{replica_status});
-	if (not defined $slave_status) {
+	my $replica_status = $dbh->selectrow_hashref($terms->{replica_status});
+	if (not defined $replica_status) {
 		say("SHOW REPLICA/SLAVE STATUS returned no data.");
 		return STATUS_REPLICATION_FAILURE;
 	}
 
 	for my $error_column (qw(Last_IO_Error Last_SQL_Error Last_Error)) {
-		if (defined $slave_status->{$error_column} && $slave_status->{$error_column} ne '') {
-			say("Replica has stopped with error ($error_column): ".$slave_status->{$error_column});
+		if (defined $replica_status->{$error_column} && $replica_status->{$error_column} ne '') {
+			say("Replica has stopped with error ($error_column): ".$replica_status->{$error_column});
 			return STATUS_REPLICATION_FAILURE;
 		}
 	}

--- a/randgen/lib/GenTest/Validator/ReplicationSlaveStatus.pm
+++ b/randgen/lib/GenTest/Validator/ReplicationSlaveStatus.pm
@@ -27,10 +27,17 @@ use GenTest;
 use GenTest::Constants;
 use GenTest::Result;
 use GenTest::Validator;
+use GenTest::Executor::MySQL;
 
-use constant SLAVE_STATUS_LAST_ERROR		=> 19;
-use constant SLAVE_STATUS_LAST_SQL_ERROR	=> 35;
-use constant SLAVE_STATUS_LAST_IO_ERROR		=> 38;
+# Previously hardcoded positional indices into SHOW SLAVE STATUS output
+# (19/35/38) -- fragile by construction, since MySQL has added columns to
+# this output across versions, and confirmed actually wrong on a live
+# Percona Server 9.7 build (Last_IO_Error sits at position 35, Last_SQL_Error
+# at 37, not 38/35). Switched to name-based access below instead: MySQL kept
+# the column names Last_Error/Last_IO_Error/Last_SQL_Error unchanged when it
+# renamed the statement itself to SHOW REPLICA STATUS in 8.0.23+, so
+# selectrow_hashref() works correctly regardless of which statement variant
+# ran, with no version-dependent column positions to track.
 
 sub init {
 	my ($validator, $executors) = @_;
@@ -39,10 +46,10 @@ sub init {
 	my ($slave_host, $slave_port) = $master_executor->slaveInfo();
 
 	if (
-		($slave_host eq '') || 
+		($slave_host eq '') ||
 		($slave_port eq '')
 	) {
-		say("SHOW SLAVE HOSTS returns no data.");
+		say("SHOW REPLICAS / SHOW SLAVE HOSTS returned no data.");
 		return STATUS_REPLICATION_FAILURE;
 	}
 	my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
@@ -57,20 +64,24 @@ sub validate {
 
 	my $master_executor = $executors->[0];
 
-	my $slave_status = $validator->dbh()->selectrow_arrayref("SHOW SLAVE STATUS");
+	# init() may have failed to obtain a slave connection (e.g. slaveInfo()
+	# found no registered replica) without that being surfaced here -- guard
+	# rather than crash the whole worker on ->selectrow_hashref() against an
+	# undef $dbh.
+	my $dbh = $validator->dbh();
+	return STATUS_WONT_HANDLE if not defined $dbh;
 
-	if ($slave_status->[SLAVE_STATUS_LAST_IO_ERROR] ne '') {
-		say("Slave IO thread has stopped with error: ".$slave_status->[SLAVE_STATUS_LAST_IO_ERROR]);
-		return STATUS_REPLICATION_FAILURE;
-	} elsif ($slave_status->[SLAVE_STATUS_LAST_SQL_ERROR] ne '') {
-		say("Slave SQL thread has stopped with error: ".$slave_status->[SLAVE_STATUS_LAST_SQL_ERROR]);
-		return STATUS_REPLICATION_FAILURE;
-	} elsif ($slave_status->[SLAVE_STATUS_LAST_ERROR] ne '') {
-		say("Slave has stopped with error: ".$slave_status->[SLAVE_STATUS_LAST_ERROR]);
-		return STATUS_REPLICATION_FAILURE;
-        } else {
-                return STATUS_OK;
-        }
+	my $modern = GenTest::Executor::MySQL::_usesModernReplicationSyntax($master_executor->version());
+	my $slave_status = $dbh->selectrow_hashref($modern ? "SHOW REPLICA STATUS" : "SHOW SLAVE STATUS");
+	return STATUS_WONT_HANDLE if not defined $slave_status;
+
+	for my $error_column (qw(Last_IO_Error Last_SQL_Error Last_Error)) {
+		if (defined $slave_status->{$error_column} && $slave_status->{$error_column} ne '') {
+			say("Replica has stopped with error ($error_column): ".$slave_status->{$error_column});
+			return STATUS_REPLICATION_FAILURE;
+		}
+	}
+	return STATUS_OK;
 }
 
 1;

--- a/randgen/lib/GenTest/Validator/ReplicationWaitForSlave.pm
+++ b/randgen/lib/GenTest/Validator/ReplicationWaitForSlave.pm
@@ -32,12 +32,12 @@ sub init {
 	my ($validator, $executors) = @_;
 	my $master_executor = $executors->[0];
 
-	my ($slave_host, $slave_port) = $master_executor->slaveInfo();
+	my ($replica_host, $replica_port) = $master_executor->replicaInfo();
 
-	if (($slave_host ne '') && ($slave_port ne '')) {
-		my $slave_dsn = 'dbi:mysql:host='.$slave_host.':port='.$slave_port.':user=root';
-		my $slave_dbh = DBI->connect($slave_dsn, undef, undef, { RaiseError => 1 });
-		$validator->setDbh($slave_dbh);
+	if (($replica_host ne '') && ($replica_port ne '')) {
+		my $replica_dsn = 'dbi:mysql:host='.$replica_host.':port='.$replica_port.':user=root';
+		my $replica_dbh = DBI->connect($replica_dsn, undef, undef, { RaiseError => 1 });
+		$validator->setDbh($replica_dbh);
 	}
 
 	return 1;
@@ -49,21 +49,21 @@ sub validate {
 	my $master_executor = $executors->[0];
 	my $terms = $master_executor->replicationTerms();
 
-	my ($file, $pos) = $master_executor->masterStatus();
+	my ($file, $pos) = $master_executor->sourceStatus();
 	return STATUS_OK if ($file eq '') || ($pos eq '');
 
-	my $slave_dbh = $validator->dbh();
-	return STATUS_OK if not defined $slave_dbh;
+	my $replica_dbh = $validator->dbh();
+	return STATUS_OK if not defined $replica_dbh;
 
-	my $wait_status = $slave_dbh->selectrow_array(
+	my $wait_status = $replica_dbh->selectrow_array(
 		"SELECT ".$terms->{pos_wait_func}."(?, ?)", undef, $file, $pos);
 
 	if (not defined $wait_status) {
-		my $slave_status = $slave_dbh->selectrow_hashref($terms->{replica_status});
-		my $err = (defined $slave_status)
-			? ($slave_status->{Last_SQL_Error} || $slave_status->{Last_Error} || '')
+		my $replica_status = $replica_dbh->selectrow_hashref($terms->{replica_status});
+		my $err = (defined $replica_status)
+			? ($replica_status->{Last_SQL_Error} || $replica_status->{Last_Error} || '')
 			: '';
-		say("Slave SQL thread has stopped with error: ".$err);
+		say("Replica SQL thread has stopped with error: ".$err);
 		return STATUS_REPLICATION_FAILURE;
 	} else {
 		return STATUS_OK;

--- a/randgen/lib/GenTest/Validator/ReplicationWaitForSlave.pm
+++ b/randgen/lib/GenTest/Validator/ReplicationWaitForSlave.pm
@@ -47,6 +47,7 @@ sub validate {
 	my ($validator, $executors, $results) = @_;
 
 	my $master_executor = $executors->[0];
+	my $terms = $master_executor->replicationTerms();
 
 	my ($file, $pos) = $master_executor->masterStatus();
 	return STATUS_OK if ($file eq '') || ($pos eq '');
@@ -54,12 +55,15 @@ sub validate {
 	my $slave_dbh = $validator->dbh();
 	return STATUS_OK if not defined $slave_dbh;
 
-	my $wait_status = $slave_dbh->selectrow_array("SELECT MASTER_POS_WAIT(?, ?)", undef, $file, $pos);
-	
+	my $wait_status = $slave_dbh->selectrow_array(
+		"SELECT ".$terms->{pos_wait_func}."(?, ?)", undef, $file, $pos);
+
 	if (not defined $wait_status) {
-		my @slave_status = $slave_dbh->selectrow_array("SHOW SLAVE STATUS");
-		my $slave_status = $slave_status[37];
-		say("Slave SQL thread has stopped with error: ".$slave_status);
+		my $slave_status = $slave_dbh->selectrow_hashref($terms->{replica_status});
+		my $err = (defined $slave_status)
+			? ($slave_status->{Last_SQL_Error} || $slave_status->{Last_Error} || '')
+			: '';
+		say("Slave SQL thread has stopped with error: ".$err);
 		return STATUS_REPLICATION_FAILURE;
 	} else {
 		return STATUS_OK;

--- a/randgen/runall-new.pl
+++ b/randgen/runall-new.pl
@@ -328,7 +328,16 @@ if ($rpl_mode ne '') {
         }
         croak("Could not start replicating server pair");
     }
-    
+
+    # The non-replication server-start branch below creates $database
+    # explicitly (see "CREATE DATABASE IF NOT EXISTS $database" further
+    # down); this branch never did, so GenTest's first connection -- and
+    # --gendata/--post-gendata-sql after it -- failed outright with
+    # "Unknown database" before a single query could run. Creating it on the
+    # master only is enough: it's ordinary DDL, so replication propagates it
+    # to the slave the same way it would propagate anything else.
+    $rplsrv->master->dbh()->do("CREATE DATABASE IF NOT EXISTS $database");
+
     $dsns[0] = $rplsrv->master->dsn($database);
     $dsns[1] = undef; ## passed to gentest. No dsn for slave!
     $server[0] = $rplsrv->master;

--- a/randgen/runall-new.pl
+++ b/randgen/runall-new.pl
@@ -223,7 +223,7 @@ if ( $build_thread eq 'auto' ) {
 
 my @ports = (10000 + 10 * $build_thread, 10000 + 10 * $build_thread + 2);
 
-say("master_port : $ports[0] slave_port : $ports[1] ports : @ports MTR_BUILD_THREAD : $build_thread ");
+say("source_port : $ports[0] replica_port : $ports[1] ports : @ports MTR_BUILD_THREAD : $build_thread ");
 
 #
 # If the user has provided two vardirs and one basedir, start second
@@ -303,11 +303,11 @@ if ($rpl_mode ne '') {
         push @options, @{$mysqld_options[0]};
     }
     $rplsrv = DBServer::MySQL::ReplMySQLd->new(basedir => $basedirs[0],
-                                               master_vardir => $vardirs[0],
+                                               source_vardir => $vardirs[0],
                                                debug_server => $debug_server[0],
-                                               master_port => $ports[0],
-                                               slave_vardir => $vardirs[1],
-                                               slave_port => $ports[1],
+                                               source_port => $ports[0],
+                                               replica_vardir => $vardirs[1],
+                                               replica_port => $ports[1],
                                                mode => $rpl_mode,
                                                server_options => \@options,
                                                valgrind => $valgrind,
@@ -320,11 +320,11 @@ if ($rpl_mode ne '') {
     if ($status > DBSTATUS_OK) {
         stopServers();
         if (osWindows()) {
-            say(system("dir ".unix2winPath($rplsrv->master->datadir)));
-            say(system("dir ".unix2winPath($rplsrv->slave->datadir)));
+            say(system("dir ".unix2winPath($rplsrv->source->datadir)));
+            say(system("dir ".unix2winPath($rplsrv->replica->datadir)));
         } else {
-            say(system("ls -l ".$rplsrv->master->datadir));
-            say(system("ls -l ".$rplsrv->slave->datadir));
+            say(system("ls -l ".$rplsrv->source->datadir));
+            say(system("ls -l ".$rplsrv->replica->datadir));
         }
         croak("Could not start replicating server pair");
     }
@@ -334,14 +334,14 @@ if ($rpl_mode ne '') {
     # down); this branch never did, so GenTest's first connection -- and
     # --gendata/--post-gendata-sql after it -- failed outright with
     # "Unknown database" before a single query could run. Creating it on the
-    # master only is enough: it's ordinary DDL, so replication propagates it
-    # to the slave the same way it would propagate anything else.
-    $rplsrv->master->dbh()->do("CREATE DATABASE IF NOT EXISTS $database");
+    # source only is enough: it's ordinary DDL, so replication propagates it
+    # to the replica the same way it would propagate anything else.
+    $rplsrv->source->dbh()->do("CREATE DATABASE IF NOT EXISTS $database");
 
-    $dsns[0] = $rplsrv->master->dsn($database);
-    $dsns[1] = undef; ## passed to gentest. No dsn for slave!
-    $server[0] = $rplsrv->master;
-    $server[1] = $rplsrv->slave;
+    $dsns[0] = $rplsrv->source->dsn($database);
+    $dsns[1] = undef; ## passed to gentest. No dsn for replica!
+    $server[0] = $rplsrv->source;
+    $server[1] = $rplsrv->replica;
 
 } elsif ($galera ne '') {
 
@@ -616,7 +616,7 @@ if ( $gentest_result != 0 ) {
     #
     if ($rpl_mode || (defined $basedirs[1]) || $galera) {
         if ($rpl_mode ne '') {
-            $rplsrv->waitForSlaveSync;
+            $rplsrv->waitForReplicaSync;
         }
         
         my @dump_files;

--- a/randgen/runall.pl
+++ b/randgen/runall.pl
@@ -59,6 +59,7 @@ if (defined $ENV{RQG_HOME}) {
 
 use Getopt::Long;
 use GenTest::Constants;
+use GenTest::ReplicationTerms qw(replicationTerms);
 use DBI;
 use Cwd;
 
@@ -429,18 +430,19 @@ if ($rpl_mode) {
 		$slave_dbh->do("SET GLOBAL BINLOG_FORMAT = '$rpl_mode'");
 	}
 
-	$slave_dbh->do("STOP SLAVE");
-
 	$slave_dbh->do("SET GLOBAL storage_engine = '$engine'") if defined $engine;
 
-	$slave_dbh->do("CHANGE MASTER TO
-		MASTER_PORT = $master_ports[0],
-		MASTER_HOST = '127.0.0.1',
-               MASTER_USER = 'root',
-               MASTER_CONNECT_RETRY = 1
+	my $terms = replicationTerms($master_version);
+	$slave_dbh->do($terms->{stop_replica});
+
+	$slave_dbh->do($terms->{change_source}."
+		".$terms->{source_port}." = $master_ports[0],
+		".$terms->{source_host}." = '127.0.0.1',
+               ".$terms->{source_user}." = 'root',
+               ".$terms->{source_connect_retry}." = 1
 	");
 
-	$slave_dbh->do("START SLAVE");
+	$slave_dbh->do($terms->{start_replica});
 }
 
 #

--- a/randgen/server.pl
+++ b/randgen/server.pl
@@ -162,10 +162,10 @@ if ($rpl_mode ne '') {
     }
     
     $rplsrv = DBServer::MySQL::ReplMySQLd->new(basedir => $basedirs[0],
-                                               master_vardir => $vardirs[0],
-                                               master_port => $ports[0],
-                                               slave_vardir => $vardirs[1],
-                                               slave_port => $ports[1],
+                                               source_vardir => $vardirs[0],
+                                               source_port => $ports[0],
+                                               replica_vardir => $vardirs[1],
+                                               replica_port => $ports[1],
                                                mode => $rpl_mode,
                                                server_options => \@options,
                                                valgrind => $valgrind,
@@ -174,18 +174,18 @@ if ($rpl_mode ne '') {
 
     if (!$just_install) {
         my $status = $rplsrv->startServer();
-        
+
         if ($status > STATUS_OK) {
             stopServers();
-            say(system("ls -l ".$rplsrv->master->datadir));
-            say(system("ls -l ".$rplsrv->slave->datadir));
+            say(system("ls -l ".$rplsrv->source->datadir));
+            say(system("ls -l ".$rplsrv->replica->datadir));
             croak("Could not start replicating server pair");
         }
-    
-        $dsns[0] = $rplsrv->master->dsn($database);
-        $dsns[1] = undef; ## passed to gentest. No dsn for slave!
-        $server[0] = $rplsrv->master;
-        $server[1] = $rplsrv->slave;
+
+        $dsns[0] = $rplsrv->source->dsn($database);
+        $dsns[1] = undef; ## passed to gentest. No dsn for replica!
+        $server[0] = $rplsrv->source;
+        $server[1] = $rplsrv->replica;
     }
         
 } else {

--- a/randgen/unit/TestReplServer.pm
+++ b/randgen/unit/TestReplServer.pm
@@ -58,39 +58,39 @@ sub create_repl_server1 {
     
     my $portbase = 30 + ($ENV{TEST_PORTBASE}?int($ENV{TEST_PORTBASE}):22120);
 
-    my $master_vardir= cwd()."/unit/tmpwd1/";
-    my $slave_vardir= cwd()."/unit/tmpwd1_slave";
-    
+    my $source_vardir= cwd()."/unit/tmpwd1/";
+    my $replica_vardir= cwd()."/unit/tmpwd1_slave";
+
     $self->assert(defined $ENV{RQG_MYSQL_BASE},"RQG_MYSQL_BASE not defined");
-    
+
     my $server = DBServer::MySQL::ReplMySQLd->new(basedir => $ENV{RQG_MYSQL_BASE},
                                                   debug_server => $debug_server,
-                                                  master_vardir => $master_vardir,
+                                                  source_vardir => $source_vardir,
                                                   mode => 'statement',
-                                                  master_port => $portbase);
+                                                  source_port => $portbase);
     $self->assert_not_null($server);
-    
-    $self->assert(-f $master_vardir."/data/mysql/db.MYD","No ".$master_vardir."/data/mysql/db.MYD");
-    $self->assert(-f $slave_vardir."/data/mysql/db.MYD","No ".$slave_vardir."/data/mysql/db.MYD");
-    
+
+    $self->assert(-f $source_vardir."/data/mysql/db.MYD","No ".$source_vardir."/data/mysql/db.MYD");
+    $self->assert(-f $replica_vardir."/data/mysql/db.MYD","No ".$replica_vardir."/data/mysql/db.MYD");
+
     $server->startServer;
-    push @pids,$server->master->serverpid;
-    push @pids,$server->slave->serverpid;
+    push @pids,$server->source->serverpid;
+    push @pids,$server->replica->serverpid;
 
 
-    $server->master->dbh->do("CREATE TABLE test.t (i integer)");
-    $server->master->dbh->do("INSERT INTO test.t VALUES(42)");
+    $server->source->dbh->do("CREATE TABLE test.t (i integer)");
+    $server->source->dbh->do("INSERT INTO test.t VALUES(42)");
 
-    $server->waitForSlaveSync();
-    
-    my $result = $server->slave->dbh->selectrow_array("SELECT * FROM test.t");
-    
+    $server->waitForReplicaSync();
+
+    my $result = $server->replica->dbh->selectrow_array("SELECT * FROM test.t");
+
     $self->assert_num_equals(42, $result);
-    
+
     $server->stopServer;
-    
-    sayFile($server->master->errorlog);
-    sayFile($server->slave->errorlog);
+
+    sayFile($server->source->errorlog);
+    sayFile($server->replica->errorlog);
 }
 
 sub create_repl_server2 {
@@ -98,47 +98,47 @@ sub create_repl_server2 {
     
     my $portbase = 30 + ($ENV{TEST_PORTBASE}?int($ENV{TEST_PORTBASE}):22120);
 
-    my $master_vardir= cwd()."/unit/tmpwd1/";
-    my $slave_vardir= cwd()."/unit/tmpwd1_slave";
-    
+    my $source_vardir= cwd()."/unit/tmpwd1/";
+    my $replica_vardir= cwd()."/unit/tmpwd1_slave";
+
     $self->assert(defined $ENV{RQG_MYSQL_BASE},"RQG_MYSQL_BASE not defined");
-    
-    my $master = DBServer::MySQL::MySQLd->new(basedir => $ENV{RQG_MYSQL_BASE},
+
+    my $source = DBServer::MySQL::MySQLd->new(basedir => $ENV{RQG_MYSQL_BASE},
                                               debug_server => $debug_server,
-                                              vardir => $master_vardir,
+                                              vardir => $source_vardir,
                                               port => $portbase);
-    my $slave = DBServer::MySQL::MySQLd->new(basedir => $ENV{RQG_MYSQL_BASE},
+    my $replica = DBServer::MySQL::MySQLd->new(basedir => $ENV{RQG_MYSQL_BASE},
                                              debug_server => $debug_server,
-                                             vardir => $slave_vardir,
+                                             vardir => $replica_vardir,
                                              port => $portbase+2);
-    
-    my $server = DBServer::MySQL::ReplMySQLd->new(slave => $slave,
-                                                  master => $master,
+
+    my $server = DBServer::MySQL::ReplMySQLd->new(replica => $replica,
+                                                  source => $source,
                                                   mode => 'mixed');
-                                             
+
     $self->assert_not_null($server);
-    
-    $self->assert(-f $master_vardir."/data/mysql/db.MYD","No ".$master_vardir."/data/mysql/db.MYD");
-    $self->assert(-f $slave_vardir."/data/mysql/db.MYD","No ".$slave_vardir."/data/mysql/db.MYD");
-    
+
+    $self->assert(-f $source_vardir."/data/mysql/db.MYD","No ".$source_vardir."/data/mysql/db.MYD");
+    $self->assert(-f $replica_vardir."/data/mysql/db.MYD","No ".$replica_vardir."/data/mysql/db.MYD");
+
     $server->startServer;
-    push @pids,$server->master->serverpid;
-    push @pids,$server->slave->serverpid;
+    push @pids,$server->source->serverpid;
+    push @pids,$server->replica->serverpid;
 
 
-    $server->master->dbh->do("CREATE TABLE test.t (i integer)");
-    $server->master->dbh->do("INSERT INTO test.t VALUES(42)");
+    $server->source->dbh->do("CREATE TABLE test.t (i integer)");
+    $server->source->dbh->do("INSERT INTO test.t VALUES(42)");
 
-    $server->waitForSlaveSync();
-    
-    my $result = $server->slave->dbh->selectrow_array("SELECT * FROM test.t");
-    
+    $server->waitForReplicaSync();
+
+    my $result = $server->replica->dbh->selectrow_array("SELECT * FROM test.t");
+
     $self->assert_num_equals(42, $result);
-    
+
     $server->stopServer;
-    
-    sayFile($server->master->errorlog);
-    sayFile($server->slave->errorlog);
+
+    sayFile($server->source->errorlog);
+    sayFile($server->replica->errorlog);
 }
 
 # Start replication server1


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-11528
perl runall-new.pl \
  --basedir=/home/saikumar/WORKDIR/PS/DEV/percona-server/bld/install \
  --vardir1=/tmp/rqg_var_rpl_master \
  --vardir2=/tmp/rqg_var_rpl_slave \
  --rpl_mode=row \
  --grammar=conf/replication/replication.yy \
  --gendata=conf/replication/replication_single_engine.zz \
  --threads=2 \
  --queries=500 \
  --duration=150 \
  --validators=ReplicationSlaveStatus \
  --reporter=Backtrace,ErrorLog,QueryTimeout \
  --sqltrace